### PR TITLE
fixed LoadAverage check

### DIFF
--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -73,6 +73,7 @@ while [ "$la" -ge "$BACKUP_LA_LIMIT" ]; do
         log_event "$E_LA" "$EVENT"
         exit $E_LA
     fi
+    la=$(cat /proc/loadavg | cut -f 1 -d ' ' | cut -f 1 -d '.')
     (( ++i))
 done
 


### PR DESCRIPTION
Variable "la" in LoadAverage check loop doesn't update. As a consequence, loop always checking the same value.
Issue #80
