### PR TITLE
v-add-dns-record: Fixed sensitive record

### DIFF
--- a/bin/v-add-dns-record
+++ b/bin/v-add-dns-record
@@ -21,7 +21,6 @@ record=$(idn -t --quiet -u "$3" )
 record=$(echo "$record" | tr '[:upper:]' '[:lower:]')
 rtype=$(echo "$4"| tr '[:lower:]' '[:upper:]')
 dvalue=$(idn -t --quiet -u "$5" )
-dvalue=$(echo "$dvalue" | tr '[:upper:]' '[:lower:]')
 priority=$6
 id=$7
 restart=$8


### PR DESCRIPTION
[RUS]: Невозможно добавить регистрочувствительную запись, т.к. выполняется '[:lower:]' над ней. Как следствие - невозможность создания правильной DNS записи для DKIM (в которой как раз используется регистрочувствительный base64). 

[ENG]: If perform [:lower:] - user can't peroperly add some records, for example
DKIM key (which is base64 encoded crypto key)
