### PR TITLE
Default DKIM keys with 1024-bit instead 512-bit

### DIFF
--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -455,7 +455,7 @@ rebuild_mail_domain_conf() {
         U_MAIL_DKMI=$((U_MAIL_DKMI + 1))
         pem="$USER_DATA/mail/$domain.pem"
         pub="$USER_DATA/mail/$domain.pub"
-        openssl genrsa -out $pem 512 &>/dev/null
+        openssl genrsa -out $pem 1024 &>/dev/null
         openssl rsa -pubout -in $pem -out $pub &>/dev/null
         cp $pem $HOMEDIR/$user/conf/mail/$domain/dkim.pem
 


### PR DESCRIPTION
Seems like Google is not very happy with the 512-bit. There are many news and blogs posts about it. 
Example: http://blog.wordtothewise.com/2012/11/gmail-sending-out-warnings-for-512-bit-dkim-keys/

I personally tested it with 1024-bit and 2048-bit and everything is working just fine.
