### PR TITLE
Updating user and group for exim4

### DIFF
--- a/bin/v-add-mail-domain-dkim
+++ b/bin/v-add-mail-domain-dkim
@@ -48,7 +48,7 @@ chmod 660 $USER_DATA/mail/$domain.*
 
 # Adding dkim to config
 cp $USER_DATA/mail/$domain.pem $HOMEDIR/$user/conf/mail/$domain/dkim.pem
-chown exim:mail $HOMEDIR/$user/conf/mail/$domain/dkim.pem
+chown Debian-exim:Debian-exim $HOMEDIR/$user/conf/mail/$domain/dkim.pem
 chmod 660 $HOMEDIR/$user/conf/mail/$domain/dkim.pem
 
 # Checking dns domain


### PR DESCRIPTION
With the current user and group we are getting the next error:
"chown: invalid user: `exim:mail'"

Tested in Ubuntu 12.04.
Exim default name details here: https://wiki.debian.org/PkgExim4UserFAQ#The_user_name_Debian-.24PACKAGE_is_too_long:_it_misaligns_ls_output_and_is_truncated_by_ps_and_atop._And_it.27s_ugly.21
