### PR TITLE
Added chmod 777 for phpmyadmin tmp folder

### DIFF
--- a/install/vst-install-ubuntu.sh
+++ b/install/vst-install-ubuntu.sh
@@ -618,6 +618,7 @@ wget $CHOST/$VERSION/apache2-pma.conf -O /etc/phpmyadmin/apache.conf
 wget $CHOST/$VERSION/pma.conf -O /etc/phpmyadmin/config.inc.php
 ln -s /etc/phpmyadmin/apache.conf /etc/apache2/conf.d/phpmyadmin.conf
 mv -f /etc/phpmyadmin/config-db.php /etc/phpmyadmin/config-db.php_
+chmod 777 /var/lib/phpmyadmin/tmp
 
 # Roundcube configuration
 wget $CHOST/$VERSION/apache2-webmail.conf -O /etc/roundcube/apache.conf


### PR DESCRIPTION
Without chmod 777 for /var/lib/phpmyadmin/tmp, uploading a sql database through phpmyadmin generates the next errors:

"Failed to load /etc/phpmyadmin/config-db.php Check group www-data has read access and open_basedir restrictions., 

PHP Warning:  Unknown: open_basedir restriction in effect. File(/tmp) is not within the allowed path(s): (/usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext) in Unknown on line 0

PHP Warning:  File upload error - unable to create a temporary file in Unknown on line 0"
