### PR TITLE
fixed 'helo_data' at exim4 config.

### DIFF
--- a/install/debian/exim4.conf.template
+++ b/install/debian/exim4.conf.template
@@ -258,7 +258,7 @@ begin transports
 ##########################################################################
 remote_smtp:
   driver = smtp
-  #helo_data = $sender_address_domain
+  helo_data = $sender_address_domain
   dkim_domain = DKIM_DOMAIN
   dkim_selector = mail
   dkim_private_key = DKIM_PRIVATE_KEY


### PR DESCRIPTION
the line that was in comment cause the sent mails 'helo_data' to be
'localhost'. most mail servers will reject mails with such helo.
the reject error is:
"504 5.5.2 <localhost>: Helo command rejected: need fully-qualified hostname"
