### PR TITLE
Small visual improve

### DIFF
--- a/install/ubuntu/exim4.conf.template
+++ b/install/ubuntu/exim4.conf.template
@@ -306,7 +306,7 @@ local_spam_delivery:
   delivery_date_add
   envelope_to_add
   return_path_add
-  directory = "${extract{5}{:}{${lookup{$local_part}lsearch{/etc/exim4/domains/$domain/passwd}}}}/mail/$domain/$local_part/.spam"
+  directory = "${extract{5}{:}{${lookup{$local_part}lsearch{/etc/exim4/domains/$domain/passwd}}}}/mail/$domain/$local_part/.Spam"
   quota = ${extract{6}{:}{${lookup{$local_part}lsearch{/etc/exim4/domains/$domain/passwd}}}}M
   quota_directory = "${extract{5}{:}{${lookup{$local_part}lsearch{/etc/exim4/domains/$domain/passwd}}}}/mail/$domain/$local_part"
   quota_warn_threshold = 75%


### PR DESCRIPTION
If "spam" is used (lowercase), in Roundcube the Spam folder is in lowercase and looks pretty unaesthetic while Inbox and Send are with first letter in Uppercase.
