### PR TITLE
add more extensions for static files in nginx config

### DIFF
--- a/web/add/web/index.php
+++ b/web/add/web/index.php
@@ -25,9 +25,11 @@ $v_ftp_email = $panel[$user]['CONTACT'];
         if (empty($_POST['v_proxy'])) $v_adv = 'yes';
         if (!empty($_POST['v_ftp'])) $v_adv = 'yes';
 
-        $v_proxy_ext = 'jpg, jpeg, gif, png, ico, svg, css, zip, tgz, gz, rar, bz2, exe, pdf, ';
-        $v_proxy_ext .= 'doc, xls, ppt, txt, odt, ods, odp, odf, tar, bmp, rtf, js, mp3, avi, ';
-        $v_proxy_ext .= 'mpeg, flv, html, htm';
+        $v_proxy_ext = 'jpeg, jpg, png, gif, bmp, ico, svg, tif, tiff, css, js, htm, html, ttf,';
+        $v_proxy_ext .= 'otf, webp, woff, txt, csv, rtf, doc, docx, xls, xlsx, ppt, pptx, odf, ';
+        $v_proxy_ext .= 'odp, ods, odt, pdf, psd, ai, eot, eps, ps, zip, tar, tgz, gz, rar, ';
+        $v_proxy_ext .= 'bz2, 7z, aac, m4a, mp3, mp4, ogg, wav, wma, 3gp, avi, flv, m4v, mkv, ';
+        $v_proxy_ext .= 'mov, mp4, mpeg, mpg, wmv, exe, iso, dmg, swf';
         if ($_POST['v_proxy_ext'] != $v_proxy_ext) $v_adv = 'yes';
 
         // Protect input

--- a/web/templates/admin/add_web.html
+++ b/web/templates/admin/add_web.html
@@ -163,7 +163,7 @@
                                     </tr>
                                     <tr>
                                         <td>
-                                            <textarea size="20" class="vst-textinput" name="v_proxy_ext"><?php if (!empty($v_proxy_ext)) { echo $v_proxy_ext;} else { echo 'jpg, jpeg, gif, png, ico, svg, css, zip, tgz, gz, rar, bz2, exe, pdf, doc, xls, ppt, txt, odt, ods, odp, odf, tar, bmp, rtf, js, mp3, avi, mpeg, flv, html, htm'; }  ?></textarea>
+                                            <textarea size="20" class="vst-textinput" name="v_proxy_ext"><?php if (!empty($v_proxy_ext)) { echo $v_proxy_ext;} else { echo 'jpeg, jpg, png, gif, bmp, ico, svg, tif, tiff, css, js, htm, html, ttf, otf, webp, woff, txt, csv, rtf, doc, docx, xls, xlsx, ppt, pptx, odf, odp, ods, odt, pdf, psd, ai, eot, eps, ps, zip, tar, tgz, gz, rar, bz2, 7z, aac, m4a, mp3, mp4, ogg, wav, wma, 3gp, avi, flv, m4v, mkv, mov, mp4, mpeg, mpg, wmv, exe, iso, dmg, swf'; }  ?></textarea>
                                         </td>
                                     </tr>
                                 </table>

--- a/web/templates/admin/edit_web.html
+++ b/web/templates/admin/edit_web.html
@@ -324,7 +324,7 @@
                                         <tr>
                                             <td class="vst-text" style="padding: 12px 0 0 0;">
                                                 <?php print __('Username');?>
-                                                <?php if (empty($v_ftp_user)) echo '<br><span style="font-size: 10pt; color:#777;">' . __('Prefix will be automaticaly added to username',$user."_") . '</span>' ?> 
+                                                <?php if (empty($v_ftp_user)) echo '<br><span style="font-size: 10pt; color:#777;">' . __('Prefix will be automaticaly added to username',$user."_") . '</span>' ?>
                                             </td>
                                         </tr>
                                         <tr>

--- a/web/templates/user/edit_web.html
+++ b/web/templates/user/edit_web.html
@@ -134,7 +134,7 @@
                                         </tr>
                                         <tr>
                                             <td>
-                                                <textarea size="20" class="vst-textinput" name="v_proxy_ext"><?php if (!empty($v_proxy_ext)) { echo $v_proxy_ext;} else { echo 'jpg, jpeg, gif, png, ico, svg, css, zip, tgz, gz, rar, bz2, exe, pdf, doc, xls, ppt, txt, odt, ods, odp, odf, tar, bmp, rtf, js, mp3, avi, mpeg, flv, html, htm'; }  ?></textarea>
+                                                <textarea size="20" class="vst-textinput" name="v_proxy_ext"><?php if (!empty($v_proxy_ext)) { echo $v_proxy_ext;} else { echo 'jpeg, jpg, png, gif, bmp, ico, svg, tif, tiff, css, js, htm, html, ttf, otf, webp, woff, txt, csv, rtf, doc, docx, xls, xlsx, ppt, pptx, odf, odp, ods, odt, pdf, psd, ai, eot, eps, ps, zip, tar, tgz, gz, rar, bz2, 7z, aac, m4a, mp3, mp4, ogg, wav, wma, 3gp, avi, flv, m4v, mkv, mov, mp4, mpeg, mpg, wmv, exe, iso, dmg, swf'; }  ?></textarea>
                                             </td>
                                         </tr>
                                     </table>


### PR DESCRIPTION
https://bugs.vestacp.com/index.php?do=details&task_id=84

Your can get more extensions from [Wikipedia](http://en.wikipedia.org/wiki/List_of_file_formats)

Now I use this list:
**Images**
jpeg, jpg, png, gif, bmp, ico, svg, tif, tiff
**Web stuff**
css, js, htm, html, ttf, otf, webp, woff
**Documents**
txt, csv, rtf, doc, docx, xls, xlsx, ppt, pptx, odf, odp, ods, odt, pdf
**Adobe**
psd, ai, eot, eps, ps
**Archives**
zip, tar, tgz, gz, rar, bz2, 7z
**Multimedia**
aac, m4a, mp3, mp4, ogg, wav, wma, 3gp, avi, flv, m4v, mkv, mov, mp4, mpeg, mpg, wmv
**Binary**
exe, iso, dmg, swf
