### PR TITLE
Small BugFix, DNS_USER variable names

### DIFF
--- a/bin/v-add-remote-dns-host
+++ b/bin/v-add-remote-dns-host
@@ -17,6 +17,9 @@ password=$4
 type=${5-api}
 dns_user=${6-dns-cluster}
 
+# fix for variable name in other files
+DNS_USER=$dns_user
+
 # Includes
 source $VESTA/func/main.sh
 source $VESTA/func/remote.sh


### PR DESCRIPTION
In all other files DNS_USER variable is in upper case, here in lower case and when adding remote dns host you are not able to change DNS_USER
