### PR TITLE
Changing conversion: 1 MB = 1024 kb

### DIFF
--- a/web/inc/main.php
+++ b/web/inc/main.php
@@ -151,12 +151,12 @@ function humanize_time($usage) {
 }
 
 function humanize_usage($usage) {
-    if ( $usage > 1000 ) {
-        $usage = $usage / 1000;
-        if ( $usage > 1000 ) {
-                $usage = $usage / 1000 ;
-                if ( $usage > 1000 ) {
-                    $usage = $usage / 1000 ;
+    if ( $usage > 1024 ) {
+        $usage = $usage / 1024;
+        if ( $usage > 1024 ) {
+                $usage = $usage / 1024 ;
+                if ( $usage > 1024 ) {
+                    $usage = $usage / 1024 ;
                     $usage = number_format($usage, 2);
                     $usage = $usage."".__('pb');
                 } else {


### PR DESCRIPTION
I found that quota is using MB as 1024 KB, but in vestacp, if you set quota for a package 1024 MB, it's showing you 1,02 GB inside the panel.

If you edit the package and add 1000 MB, it's showing correctly in the panel, 1GB, but quota is exceeded at 976 MB.

humanize_usage use 1000 MB as 1GB instead of 1024 MB, so I fixed it.
