### PR TITLE
simple exim ACL fix: act correctly on DNSBL+authentication

### DIFF
--- a/install/debian/exim4.conf.template
+++ b/install/debian/exim4.conf.template
@@ -51,8 +51,6 @@ acl_check_spammers:
   drop    message       = Your host in blacklist on this server.
           log_message   = Host in blacklist
           hosts         = +spammers
-  deny    message       = rejected because $sender_host_address is in a black list at $dnslist_domain\\n$dnslist_text
-          dnslists      = ${readfile {/etc/exim4/dnsbl.conf}{:}}
   accept
 
 acl_check_mail:
@@ -101,6 +99,10 @@ acl_check_rcpt:
 
   accept  authenticated = *
           control       = submission/domain=
+
+  deny    message       = rejected because $sender_host_address is in a black list at $dnslist_domain\\n$dnslist_text
+	  hosts		= !+whitelist
+          dnslists      = ${readfile {/etc/exim4/dnsbl.conf}{:}}
 
   require message       = relay not permitted
           domains       = +local_domains : +relay_to_domains

--- a/install/rhel/exim-smarthost.conf
+++ b/install/rhel/exim-smarthost.conf
@@ -51,8 +51,6 @@ acl_check_spammers:
   drop    message       = Your host in blacklist on this server.
           log_message   = Host in blacklist
           hosts         = +spammers
-  deny    message       = rejected because $sender_host_address is in a black list at $dnslist_domain\\n$dnslist_text
-          dnslists      = ${readfile {/etc/exim/dnsbl.conf}{:}}
   accept
 
 acl_check_mail:
@@ -101,6 +99,10 @@ acl_check_rcpt:
 
   accept  authenticated = *
           control       = submission/domain=
+
+  deny    message       = rejected because $sender_host_address is in a black list at $dnslist_domain\\n$dnslist_text
+          hosts		= !+whitelist
+          dnslists      = ${readfile {/etc/exim/dnsbl.conf}{:}}
 
   require message       = relay not permitted
           domains       = +local_domains : +relay_to_domains

--- a/install/rhel/exim.conf
+++ b/install/rhel/exim.conf
@@ -51,8 +51,6 @@ acl_check_spammers:
   drop    message       = Your host in blacklist on this server.
           log_message   = Host in blacklist
           hosts         = +spammers
-  deny    message       = rejected because $sender_host_address is in a black list at $dnslist_domain\\n$dnslist_text
-          dnslists      = ${readfile {/etc/exim/dnsbl.conf}{:}}
   accept
 
 acl_check_mail:
@@ -101,6 +99,10 @@ acl_check_rcpt:
 
   accept  authenticated = *
           control       = submission/domain=
+
+  deny    message       = rejected because $sender_host_address is in a black list at $dnslist_domain\\n$dnslist_text
+	  hosts		= !+whitelist
+          dnslists      = ${readfile {/etc/exim/dnsbl.conf}{:}}
 
   require message       = relay not permitted
           domains       = +local_domains : +relay_to_domains

--- a/install/ubuntu/exim4.conf.template
+++ b/install/ubuntu/exim4.conf.template
@@ -51,8 +51,6 @@ acl_check_spammers:
   drop    message       = Your host in blacklist on this server.
           log_message   = Host in blacklist
           hosts         = +spammers
-  deny    message       = rejected because $sender_host_address is in a black list at $dnslist_domain\\n$dnslist_text
-          dnslists      = ${readfile {/etc/exim4/dnsbl.conf}{:}}
   accept
 
 acl_check_mail:
@@ -101,6 +99,10 @@ acl_check_rcpt:
 
   accept  authenticated = *
           control       = submission/domain=
+
+  deny    message       = rejected because $sender_host_address is in a black list at $dnslist_domain\\n$dnslist_text
+	  hosts		= !+whitelist
+          dnslists      = ${readfile {/etc/exim4/dnsbl.conf}{:}}
 
   require message       = relay not permitted
           domains       = +local_domains : +relay_to_domains


### PR DESCRIPTION
When an (possibly) authenticated user tried to send mail from an address listed on any DNSBL, he was rejected without any chance to authenticate (and prove he's not a spammer).

This rearranges the order of checks so that authentication is possible even from DNSBL'd IP.
