### PR TITLE
Updated default DKIM key size from 1024 to 2048

### DIFF
--- a/bin/v-add-mail-domain
+++ b/bin/v-add-mail-domain
@@ -18,7 +18,7 @@ domain_idn=$(idn -t --quiet -a "$domain")
 antispam=${3-yes}
 antivirus=${4-yes}
 dkim=${5-yes}
-dkim_size=${6-1024}
+dkim_size=${6-2048}
 
 # Includes
 source $VESTA/func/main.sh

--- a/bin/v-add-mail-domain-dkim
+++ b/bin/v-add-mail-domain-dkim
@@ -14,7 +14,7 @@ user=$1
 domain=$(idn -t --quiet -u "$2" )
 domain=$(echo $domain | tr '[:upper:]' '[:lower:]')
 domain_idn=$(idn -t --quiet -a "$domain")
-dkim_size=${3-1024}
+dkim_size=${3-2048}
 
 # Includes
 source $VESTA/func/main.sh


### PR DESCRIPTION
Updated default DKIM size to 2048, some providers say 1024 key is small, recommended size is 2048
