### PR TITLE
Cut blank lines when counting domains for IP addresses

### DIFF
--- a/bin/v-update-sys-ip-counters
+++ b/bin/v-update-sys-ip-counters
@@ -45,7 +45,7 @@ for ip in $ip_list; do
 
     # Calculate usage
     ip_usage=$(grep -H $ip $VESTA/data/users/*/web.conf)
-    web_domains=$(echo "$ip_usage"| wc -l)
+    web_domains=$(echo "$ip_usage" | sed '/^$/' | wc -l)
     sys_users=$(echo "$ip_usage" | cut -f7 -d/ | sort -u |\
         tr '\n' ',' | sed "s/,$//g")
 

--- a/bin/v-update-sys-ip-counters
+++ b/bin/v-update-sys-ip-counters
@@ -45,7 +45,7 @@ for ip in $ip_list; do
 
     # Calculate usage
     ip_usage=$(grep -H $ip $VESTA/data/users/*/web.conf)
-    web_domains=$(echo "$ip_usage" | sed '/^$/' | wc -l)
+    web_domains=$(echo "$ip_usage" | sed '/^$/d' | wc -l)
     sys_users=$(echo "$ip_usage" | cut -f7 -d/ | sort -u |\
         tr '\n' ',' | sed "s/,$//g")
 


### PR DESCRIPTION
I had an issue where Vesta was reporting 1 domain for an IP address that I was sure had zero. I inspected the output of v-update-sys-ip-counters and discovered it was counting one blank line. This was my fix locally; don't know if it's the best way to do it but I wanted to put it out there.