### PR TITLE
Fix bug with cyrillic in mail address

### DIFF
--- a/func/domain.sh
+++ b/func/domain.sh
@@ -367,7 +367,7 @@ del_web_config() {
 # Update web domain values
 upd_web_domain_values() {
     group="$user"
-    email="info@$domain"
+    email="info@$domain_idn"
     docroot="$HOMEDIR/$user/web/$domain/public_html"
     sdocroot=$docroot
     if [ "$SSL_HOME" = 'single' ]; then


### PR DESCRIPTION
If for cyrillic domains use a template Apache "hosting", then stopped working php-function mail(). Error in the transmission of cyrillic characters per line "php_admin_value sendmail_path '/usr/sbin/sendmail -t -i -f info@**%email%**'" in .tpl file