### PR TITLE
updated apache template 'basedir'

### DIFF
--- a/install/debian/templates/web/apache2/basedir.stpl
+++ b/install/debian/templates/web/apache2/basedir.stpl
@@ -15,7 +15,9 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%
+        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/debian/templates/web/apache2/basedir.tpl
+++ b/install/debian/templates/web/apache2/basedir.tpl
@@ -14,7 +14,9 @@
     <Directory %docroot%>
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%
+        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/templates/web/httpd/basedir.stpl
+++ b/install/rhel/templates/web/httpd/basedir.stpl
@@ -15,7 +15,9 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%
+        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/templates/web/httpd/basedir.tpl
+++ b/install/rhel/templates/web/httpd/basedir.tpl
@@ -14,7 +14,9 @@
     <Directory %docroot%>
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%
+        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/templates/web/apache2/basedir.stpl
@@ -15,7 +15,9 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%
+        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/templates/web/apache2/basedir.tpl
@@ -14,7 +14,9 @@
     <Directory %docroot%>
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%
+        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All


### PR DESCRIPTION
updated apache template 'basedir' for allowing writing access to the user's temporary directory.
a problem description (russian): https://forum.vestacp.com/viewtopic.php?f=11&t=5187
the fix tested on ubuntu 14.04.