### PR TITLE
Update exim.conf

### DIFF
--- a/install/rhel/exim.conf
+++ b/install/rhel/exim.conf
@@ -8,7 +8,7 @@
 #SPAM_SCORE = 50
 #CLAMD =  yes
 
-domainlist local_domains = dsearch;/etc/exim/domains/
+domainlist local_domains = @ : localhost : dsearch;/etc/exim/domains/
 domainlist relay_to_domains = dsearch;/etc/exim/domains/
 hostlist relay_from_hosts = 127.0.0.1
 hostlist whitelist = net-iplsearch;/etc/exim/white-blocks.conf


### PR DESCRIPTION
This allows us to route local-based email addresses, eg.:

root
root@localhost
root@fqdn.hostname.tld

Without it, only local username is working. @localhost and @fqdn.hostname.tld is not working. Check the routing:

$ exim -bt root
$ exim -bt root@localhost
$ exim -bt root@fqdn.hostname.tld

The .forward file inside user's home will also going to work when a local domain after the username was appended, eg.: /root/.forward (routed via userforward route config). Most scripts/crons sends an email with local domain included (eg. root@localhost or root@fqdn.hostname.tld) and not just the username.

This is useful if you wish to forward user's emails (true for root emails) to an external email address. Useful for cron scripts, bounces from /bin/mail, etc.