### PR TITLE
Security vulnerabilities fix

### DIFF
--- a/src/v-check-user-password.c
+++ b/src/v-check-user-password.c
@@ -45,8 +45,14 @@ int main (int argc, char** argv) {
     /* open log file */
     FILE* pFile = fopen ("/usr/local/vesta/log/auth.log","a+");
     if (NULL == pFile) {
-        printf("Error: can not open file %s \n", argv[0]);
+        printf("Error: can not open file /usr/local/vesta/log/auth.log \n");
         exit(12);
+    }
+
+    int len = 0;
+    if(strlen(argv[1]) >= 100) {
+        printf("Too long username\n");
+        exit(1);
     }
 
     /* parse user argument */

--- a/web/api/index.php
+++ b/web/api/index.php
@@ -14,7 +14,8 @@ if (isset($_POST['user']) || isset($_POST['hash'])) {
         
         $v_user = escapeshellarg($_POST['user']);
         $v_password = escapeshellarg($_POST['password']);
-        exec(VESTA_CMD ."v-check-user-password ".$v_user." ".$v_password." '".$_SERVER["REMOTE_ADDR"]."'",  $output, $auth_code);
+        $v_ip_addr = escapeshellarg($_SERVER["REMOTE_ADDR"]);
+        exec(VESTA_CMD ."v-check-user-password ".$v_user." ".$v_password." '".$v_ip_addr."'",  $output, $auth_code);
     } else {
         $key = '/usr/local/vesta/data/keys/' . basename($_POST['hash']);
         if (file_exists($key) && is_file($key)) {

--- a/web/api/index.php
+++ b/web/api/index.php
@@ -17,7 +17,7 @@ if (isset($_POST['user']) || isset($_POST['hash'])) {
         exec(VESTA_CMD ."v-check-user-password ".$v_user." ".$v_password." '".$_SERVER["REMOTE_ADDR"]."'",  $output, $auth_code);
     } else {
         $key = '/usr/local/vesta/data/keys/' . basename($_POST['hash']);
-        if (file_exists($key)) {
+        if (file_exists($key) && is_file($key)) {
             $auth_code = '0';
         }
     }


### PR DESCRIPTION
Please check all of your code for similar errors.
Also, be sure to know,  when you use "escapeshellargs", command line arguments can be passed to the script anyway. For example:
$port = escapeshellargs("31337 -e /bin/sh");
exec("nc -l -p ".$port);

So, if your script in exec can be exploited by specifying any harmful command line argument - it will be exploited.