### PR TITLE
Fix bug with redurant redirect

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -1,7 +1,7 @@
 <?php
 session_start();
 if (isset($_SESSION['user'])) {
-    header("Location: /list/user");
+    header("Location: /list/user/");
 } else {
     header("Location: /login/");
 }


### PR DESCRIPTION
If I use nginx to assign 127.0.0.1:8083 with one of named VirtualHost - I have error when login by user (Browser redirect me to self domain name with 8083 port, which is already closed).
Also this fix doesn't break anything on default use.