### PR TITLE
HTTP on 8083 and WHMCS module fixes

### DIFF
--- a/install/debian/whmcs-module.php
+++ b/install/debian/whmcs-module.php
@@ -43,6 +43,8 @@ function vesta_CreateAccount($params) {
         curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
         $answer = curl_exec($curl);
 
+		logModuleCall('vesta','CreateAccount_UserAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+
         // Enable ssh access
         if(($answer == 'OK') && ($params["configoption2"] == 'on')) {
             $postvars = array(
@@ -62,6 +64,8 @@ function vesta_CreateAccount($params) {
             curl_setopt($curl, CURLOPT_POST, true);
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
             $answer = curl_exec($curl);
+
+            logModuleCall('vesta','CreateAccount_EnableSSH','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
         }
 
         // Add domain
@@ -84,6 +88,8 @@ function vesta_CreateAccount($params) {
             curl_setopt($curl, CURLOPT_POST, true);
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
             $answer = curl_exec($curl);
+
+            logModuleCall('vesta','CreateAccount_AddDomain','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
         }
     }
 
@@ -92,8 +98,8 @@ function vesta_CreateAccount($params) {
     } else {
         $result = $answer;
     }
-    return $result;
 
+    return $result;
 }
 
 function vesta_TerminateAccount($params) {
@@ -122,6 +128,8 @@ function vesta_TerminateAccount($params) {
         $answer = curl_exec($curl);
     }
 
+	logModuleCall('vesta','TerminateAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+
     if($answer == 'OK') {
         $result = "success";
     } else {
@@ -129,7 +137,6 @@ function vesta_TerminateAccount($params) {
     }
 
     return $result;
-
 }
 
 function vesta_SuspendAccount($params) {
@@ -158,12 +165,15 @@ function vesta_SuspendAccount($params) {
         $answer = curl_exec($curl);
     }
 
+	logModuleCall('vesta','SuspendAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+
     if($answer == 'OK') {
         $result = "success";
     } else {
         $result = $answer;
     }
 
+    return $result;
 }
 
 function vesta_UnsuspendAccount($params) {
@@ -192,12 +202,15 @@ function vesta_UnsuspendAccount($params) {
         $answer = curl_exec($curl);
     }
 
+    logModuleCall('vesta','UnsuspendAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+
     if($answer == 'OK') {
         $result = "success";
     } else {
         $result = $answer;
     }
 
+    return $result;
 }
 
 function vesta_ChangePassword($params) {
@@ -227,13 +240,15 @@ function vesta_ChangePassword($params) {
         $answer = curl_exec($curl);
     }
 
+	logModuleCall('vesta','ChangePassword','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+
     if($answer == 'OK') {
         $result = "success";
     } else {
         $result = $answer;
     }
+    
     return $result;
-
 }
 
 function vesta_ChangePackage($params) {
@@ -263,13 +278,15 @@ function vesta_ChangePackage($params) {
         $answer = curl_exec($curl);
     }
 
+	logModuleCall('vesta','ChangePackage','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+
     if($answer == 'OK') {
         $result = "success";
     } else {
         $result = $answer;
     }
-    return $result;
 
+    return $result;
 }
 
 function vesta_ClientArea($params) {

--- a/install/debian/whmcs-module.php
+++ b/install/debian/whmcs-module.php
@@ -43,7 +43,7 @@ function vesta_CreateAccount($params) {
         curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
         $answer = curl_exec($curl);
 
-		logModuleCall('vesta','CreateAccount_UserAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+		logModuleCall('vesta','CreateAccount_UserAccount','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
 
         // Enable ssh access
         if(($answer == 'OK') && ($params["configoption2"] == 'on')) {
@@ -65,7 +65,7 @@ function vesta_CreateAccount($params) {
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
             $answer = curl_exec($curl);
 
-            logModuleCall('vesta','CreateAccount_EnableSSH','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+            logModuleCall('vesta','CreateAccount_EnableSSH','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
         }
 
         // Add domain
@@ -89,7 +89,7 @@ function vesta_CreateAccount($params) {
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
             $answer = curl_exec($curl);
 
-            logModuleCall('vesta','CreateAccount_AddDomain','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+            logModuleCall('vesta','CreateAccount_AddDomain','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
         }
     }
 
@@ -128,7 +128,7 @@ function vesta_TerminateAccount($params) {
         $answer = curl_exec($curl);
     }
 
-	logModuleCall('vesta','TerminateAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+	logModuleCall('vesta','TerminateAccount','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
 
     if($answer == 'OK') {
         $result = "success";
@@ -165,7 +165,7 @@ function vesta_SuspendAccount($params) {
         $answer = curl_exec($curl);
     }
 
-	logModuleCall('vesta','SuspendAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+	logModuleCall('vesta','SuspendAccount','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
 
     if($answer == 'OK') {
         $result = "success";
@@ -202,7 +202,7 @@ function vesta_UnsuspendAccount($params) {
         $answer = curl_exec($curl);
     }
 
-    logModuleCall('vesta','UnsuspendAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+    logModuleCall('vesta','UnsuspendAccount','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
 
     if($answer == 'OK') {
         $result = "success";
@@ -240,7 +240,7 @@ function vesta_ChangePassword($params) {
         $answer = curl_exec($curl);
     }
 
-	logModuleCall('vesta','ChangePassword','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+	logModuleCall('vesta','ChangePassword','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
 
     if($answer == 'OK') {
         $result = "success";
@@ -278,7 +278,7 @@ function vesta_ChangePackage($params) {
         $answer = curl_exec($curl);
     }
 
-	logModuleCall('vesta','ChangePackage','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+	logModuleCall('vesta','ChangePackage','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
 
     if($answer == 'OK') {
         $result = "success";

--- a/install/rhel/whmcs-module.php
+++ b/install/rhel/whmcs-module.php
@@ -43,6 +43,8 @@ function vesta_CreateAccount($params) {
         curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
         $answer = curl_exec($curl);
 
+		logModuleCall('vesta','CreateAccount_UserAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+
         // Enable ssh access
         if(($answer == 'OK') && ($params["configoption2"] == 'on')) {
             $postvars = array(
@@ -62,6 +64,8 @@ function vesta_CreateAccount($params) {
             curl_setopt($curl, CURLOPT_POST, true);
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
             $answer = curl_exec($curl);
+
+            logModuleCall('vesta','CreateAccount_EnableSSH','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
         }
 
         // Add domain
@@ -84,6 +88,8 @@ function vesta_CreateAccount($params) {
             curl_setopt($curl, CURLOPT_POST, true);
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
             $answer = curl_exec($curl);
+
+            logModuleCall('vesta','CreateAccount_AddDomain','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
         }
     }
 
@@ -92,8 +98,8 @@ function vesta_CreateAccount($params) {
     } else {
         $result = $answer;
     }
-    return $result;
 
+    return $result;
 }
 
 function vesta_TerminateAccount($params) {
@@ -122,6 +128,8 @@ function vesta_TerminateAccount($params) {
         $answer = curl_exec($curl);
     }
 
+	logModuleCall('vesta','TerminateAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+
     if($answer == 'OK') {
         $result = "success";
     } else {
@@ -129,7 +137,6 @@ function vesta_TerminateAccount($params) {
     }
 
     return $result;
-
 }
 
 function vesta_SuspendAccount($params) {
@@ -158,12 +165,15 @@ function vesta_SuspendAccount($params) {
         $answer = curl_exec($curl);
     }
 
+	logModuleCall('vesta','SuspendAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+
     if($answer == 'OK') {
         $result = "success";
     } else {
         $result = $answer;
     }
 
+    return $result;
 }
 
 function vesta_UnsuspendAccount($params) {
@@ -192,12 +202,15 @@ function vesta_UnsuspendAccount($params) {
         $answer = curl_exec($curl);
     }
 
+    logModuleCall('vesta','UnsuspendAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+
     if($answer == 'OK') {
         $result = "success";
     } else {
         $result = $answer;
     }
 
+    return $result;
 }
 
 function vesta_ChangePassword($params) {
@@ -227,13 +240,15 @@ function vesta_ChangePassword($params) {
         $answer = curl_exec($curl);
     }
 
+	logModuleCall('vesta','ChangePassword','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+
     if($answer == 'OK') {
         $result = "success";
     } else {
         $result = $answer;
     }
+    
     return $result;
-
 }
 
 function vesta_ChangePackage($params) {
@@ -263,13 +278,15 @@ function vesta_ChangePackage($params) {
         $answer = curl_exec($curl);
     }
 
+	logModuleCall('vesta','ChangePackage','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+
     if($answer == 'OK') {
         $result = "success";
     } else {
         $result = $answer;
     }
-    return $result;
 
+    return $result;
 }
 
 function vesta_ClientArea($params) {

--- a/install/rhel/whmcs-module.php
+++ b/install/rhel/whmcs-module.php
@@ -43,7 +43,7 @@ function vesta_CreateAccount($params) {
         curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
         $answer = curl_exec($curl);
 
-		logModuleCall('vesta','CreateAccount_UserAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+		logModuleCall('vesta','CreateAccount_UserAccount','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
 
         // Enable ssh access
         if(($answer == 'OK') && ($params["configoption2"] == 'on')) {
@@ -65,7 +65,7 @@ function vesta_CreateAccount($params) {
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
             $answer = curl_exec($curl);
 
-            logModuleCall('vesta','CreateAccount_EnableSSH','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+            logModuleCall('vesta','CreateAccount_EnableSSH','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
         }
 
         // Add domain
@@ -89,7 +89,7 @@ function vesta_CreateAccount($params) {
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
             $answer = curl_exec($curl);
 
-            logModuleCall('vesta','CreateAccount_AddDomain','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+            logModuleCall('vesta','CreateAccount_AddDomain','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
         }
     }
 
@@ -128,7 +128,7 @@ function vesta_TerminateAccount($params) {
         $answer = curl_exec($curl);
     }
 
-	logModuleCall('vesta','TerminateAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+	logModuleCall('vesta','TerminateAccount','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
 
     if($answer == 'OK') {
         $result = "success";
@@ -165,7 +165,7 @@ function vesta_SuspendAccount($params) {
         $answer = curl_exec($curl);
     }
 
-	logModuleCall('vesta','SuspendAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+	logModuleCall('vesta','SuspendAccount','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
 
     if($answer == 'OK') {
         $result = "success";
@@ -202,7 +202,7 @@ function vesta_UnsuspendAccount($params) {
         $answer = curl_exec($curl);
     }
 
-    logModuleCall('vesta','UnsuspendAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+    logModuleCall('vesta','UnsuspendAccount','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
 
     if($answer == 'OK') {
         $result = "success";
@@ -240,7 +240,7 @@ function vesta_ChangePassword($params) {
         $answer = curl_exec($curl);
     }
 
-	logModuleCall('vesta','ChangePassword','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+	logModuleCall('vesta','ChangePassword','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
 
     if($answer == 'OK') {
         $result = "success";
@@ -278,7 +278,7 @@ function vesta_ChangePackage($params) {
         $answer = curl_exec($curl);
     }
 
-	logModuleCall('vesta','ChangePackage','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+	logModuleCall('vesta','ChangePackage','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
 
     if($answer == 'OK') {
         $result = "success";

--- a/install/ubuntu/whmcs-module.php
+++ b/install/ubuntu/whmcs-module.php
@@ -43,6 +43,8 @@ function vesta_CreateAccount($params) {
         curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
         $answer = curl_exec($curl);
 
+		logModuleCall('vesta','CreateAccount_UserAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+
         // Enable ssh access
         if(($answer == 'OK') && ($params["configoption2"] == 'on')) {
             $postvars = array(
@@ -62,6 +64,8 @@ function vesta_CreateAccount($params) {
             curl_setopt($curl, CURLOPT_POST, true);
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
             $answer = curl_exec($curl);
+
+            logModuleCall('vesta','CreateAccount_EnableSSH','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
         }
 
         // Add domain
@@ -84,6 +88,8 @@ function vesta_CreateAccount($params) {
             curl_setopt($curl, CURLOPT_POST, true);
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
             $answer = curl_exec($curl);
+
+            logModuleCall('vesta','CreateAccount_AddDomain','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
         }
     }
 
@@ -92,8 +98,8 @@ function vesta_CreateAccount($params) {
     } else {
         $result = $answer;
     }
-    return $result;
 
+    return $result;
 }
 
 function vesta_TerminateAccount($params) {
@@ -122,6 +128,8 @@ function vesta_TerminateAccount($params) {
         $answer = curl_exec($curl);
     }
 
+	logModuleCall('vesta','TerminateAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+
     if($answer == 'OK') {
         $result = "success";
     } else {
@@ -129,7 +137,6 @@ function vesta_TerminateAccount($params) {
     }
 
     return $result;
-
 }
 
 function vesta_SuspendAccount($params) {
@@ -158,12 +165,15 @@ function vesta_SuspendAccount($params) {
         $answer = curl_exec($curl);
     }
 
+	logModuleCall('vesta','SuspendAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+
     if($answer == 'OK') {
         $result = "success";
     } else {
         $result = $answer;
     }
 
+    return $result;
 }
 
 function vesta_UnsuspendAccount($params) {
@@ -192,12 +202,15 @@ function vesta_UnsuspendAccount($params) {
         $answer = curl_exec($curl);
     }
 
+    logModuleCall('vesta','UnsuspendAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+
     if($answer == 'OK') {
         $result = "success";
     } else {
         $result = $answer;
     }
 
+    return $result;
 }
 
 function vesta_ChangePassword($params) {
@@ -227,13 +240,15 @@ function vesta_ChangePassword($params) {
         $answer = curl_exec($curl);
     }
 
+	logModuleCall('vesta','ChangePassword','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+
     if($answer == 'OK') {
         $result = "success";
     } else {
         $result = $answer;
     }
+    
     return $result;
-
 }
 
 function vesta_ChangePackage($params) {
@@ -263,13 +278,15 @@ function vesta_ChangePackage($params) {
         $answer = curl_exec($curl);
     }
 
+	logModuleCall('vesta','ChangePackage','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+
     if($answer == 'OK') {
         $result = "success";
     } else {
         $result = $answer;
     }
-    return $result;
 
+    return $result;
 }
 
 function vesta_ClientArea($params) {

--- a/install/ubuntu/whmcs-module.php
+++ b/install/ubuntu/whmcs-module.php
@@ -43,7 +43,7 @@ function vesta_CreateAccount($params) {
         curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
         $answer = curl_exec($curl);
 
-		logModuleCall('vesta','CreateAccount_UserAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+		logModuleCall('vesta','CreateAccount_UserAccount','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
 
         // Enable ssh access
         if(($answer == 'OK') && ($params["configoption2"] == 'on')) {
@@ -65,7 +65,7 @@ function vesta_CreateAccount($params) {
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
             $answer = curl_exec($curl);
 
-            logModuleCall('vesta','CreateAccount_EnableSSH','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+            logModuleCall('vesta','CreateAccount_EnableSSH','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
         }
 
         // Add domain
@@ -89,7 +89,7 @@ function vesta_CreateAccount($params) {
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
             $answer = curl_exec($curl);
 
-            logModuleCall('vesta','CreateAccount_AddDomain','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+            logModuleCall('vesta','CreateAccount_AddDomain','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
         }
     }
 
@@ -128,7 +128,7 @@ function vesta_TerminateAccount($params) {
         $answer = curl_exec($curl);
     }
 
-	logModuleCall('vesta','TerminateAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+	logModuleCall('vesta','TerminateAccount','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
 
     if($answer == 'OK') {
         $result = "success";
@@ -165,7 +165,7 @@ function vesta_SuspendAccount($params) {
         $answer = curl_exec($curl);
     }
 
-	logModuleCall('vesta','SuspendAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+	logModuleCall('vesta','SuspendAccount','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
 
     if($answer == 'OK') {
         $result = "success";
@@ -202,7 +202,7 @@ function vesta_UnsuspendAccount($params) {
         $answer = curl_exec($curl);
     }
 
-    logModuleCall('vesta','UnsuspendAccount','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+    logModuleCall('vesta','UnsuspendAccount','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
 
     if($answer == 'OK') {
         $result = "success";
@@ -240,7 +240,7 @@ function vesta_ChangePassword($params) {
         $answer = curl_exec($curl);
     }
 
-	logModuleCall('vesta','ChangePassword','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+	logModuleCall('vesta','ChangePassword','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
 
     if($answer == 'OK') {
         $result = "success";
@@ -278,7 +278,7 @@ function vesta_ChangePackage($params) {
         $answer = curl_exec($curl);
     }
 
-	logModuleCall('vesta','ChangePackage','https://'.$params["serverhostname"].':8083/api/'$postdata,$answer);
+	logModuleCall('vesta','ChangePackage','https://'.$params["serverhostname"].':8083/api/'.$postdata,$answer);
 
     if($answer == 'OK') {
         $result = "success";

--- a/src/rpm/conf/nginx.conf
+++ b/src/rpm/conf/nginx.conf
@@ -82,6 +82,9 @@ http {
         root            /usr/local/vesta/web;
         charset         utf-8;
 
+        // Fix error "The plain HTTP request was sent to HTTPS port"
+        error_page      497 https://$host:$server_port$request_uri;
+
         ssl                  on;
         ssl_certificate      /usr/local/vesta/ssl/certificate.crt;
         ssl_certificate_key  /usr/local/vesta/ssl/certificate.key;


### PR DESCRIPTION
HTTP connection on 8083 now redirects to same URI over HTTPS schema instead of 4XX error.

WHMCS Module small fixes, now suspend/unsuspend commands report to WHMCS correctly.

WHMCS Module debug logging added for better issue troubleshooting. This logs are accessable directly from WHMCS admin interface.