### PR TITLE
dubbel line removed

### DIFF
--- a/bin/v-delete-user
+++ b/bin/v-delete-user
@@ -91,7 +91,7 @@ sed -i "/ $user$/d" $VESTA/data/queue/traffic.pipe
 
 # Deleting system user
 /usr/sbin/userdel -f $user >> /dev/null 2>&1
-/usr/sbin/userdel -f $user >> /dev/null 2>&1
+
 if [ "$?" != 0 ]; then
     sed -i "/^$user:/d" /etc/passwd
     sed -i "/^$user:/d" /etc/shadow


### PR DESCRIPTION
Line 93 & 94 are the same: /usr/sbin/userdel -f $user >> /dev/null 2>&1