### PR TITLE
[FIX] Wrong dovecot.tar.gz location for CentOS 6/7

### DIFF
--- a/install/vst-install-rhel.sh
+++ b/install/vst-install-rhel.sh
@@ -725,12 +725,19 @@ fi
 if [ "$release" -eq '5' ]; then
     wget $CHOST/$VERSION/dovecot.conf -O /etc/dovecot.conf
 else
-    wget $CHOST/$VERSION/dovecot.tar.gz -O  /etc/dovecot.tar.gz
-    cd /etc/
-    rm -rf dovecot
+    wget $CHOST/$VERSION/$release/dovecot.tar.gz -O  /etc/dovecot.tar.gz
+    cd /etc
+    if [ -d /etc/dovecot ]; then
+        rm -rf /etc/dovecot
+    fi
+    if [ -f /etc/dovecot.conf ]; then
+        rm /etc/dovecot.conf
+    fi
     tar -xzf dovecot.tar.gz
     rm -f dovecot.tar.gz
-    chown -R root:root /etc/dovecot
+    if [ -d /etc/dovecot ]; then
+        chown -R root:root /etc/dovecot
+    fi
 fi
 gpasswd -a dovecot mail
 chkconfig dovecot on


### PR DESCRIPTION
Fresh install on CentOS 6.6 would fail at starting dovecot because the wrong configuration files were being pulled for the installer.
This would cause /etc/init.d/dovecot to fail with exit status 6 (no config found) because the config would end up at /etc/dovecot.conf instead of /etc/dovecot/dovecot.conf
It would also generate an error when it couldn't chown /etc/dovecot when the folder didn't exist.

Have not changed anything for CentOS 5.x