### PR TITLE
nginx.conf fixed to gzip all JavaScript

### DIFF
--- a/install/debian/nginx.conf
+++ b/install/debian/nginx.conf
@@ -52,7 +52,7 @@ http {
     gzip_min_length     512;
     gzip_buffers        8 64k;
     gzip_types          text/plain text/css text/javascript
-                        application/x-javascript;
+                        application/x-javascript application/javascript;
     gzip_proxied        any;
 
 

--- a/install/rhel/mysql-512.cnf
+++ b/install/rhel/mysql-512.cnf
@@ -11,7 +11,7 @@ long_query_time=5
 #log-queries-not-using-indexes
 #log-slow-queries=/var/log/mysql/log-slow-queries.log
 
-key_buffer = 16M
+key_buffer_size = 16M
 myisam_sort_buffer_size = 32M
 join_buffer_size=1M
 read_buffer_size=1M

--- a/install/rhel/nginx.conf
+++ b/install/rhel/nginx.conf
@@ -52,7 +52,7 @@ http {
     gzip_min_length     512;
     gzip_buffers        8 64k;
     gzip_types          text/plain text/css text/javascript
-                        application/x-javascript;
+                        application/x-javascript application/javascript;
     gzip_proxied        any;
 
 

--- a/install/ubuntu/nginx.conf
+++ b/install/ubuntu/nginx.conf
@@ -52,7 +52,7 @@ http {
     gzip_min_length     512;
     gzip_buffers        8 64k;
     gzip_types          text/plain text/css text/javascript
-                        application/x-javascript;
+                        application/x-javascript application/javascript;
     gzip_proxied        any;
 
 


### PR DESCRIPTION
Issue #412 fixed by adding ```application/javascript``` to ```gzip_types``` in ```nginx.conf``` for all three OS configs.