### PR TITLE
Опечатка в названии переменной

### DIFF
--- a/bin/v-change-fs-file-permission
+++ b/bin/v-change-fs-file-permission
@@ -37,7 +37,7 @@ if [ -z "$(echo $rpath |egrep "^/tmp|^$homedir")" ]; then
 fi
 
 # Changing file permissions
-sudo -u $user chmod $permisions $src_file >/dev/null 2>&1
+sudo -u $user chmod $permissions $src_file >/dev/null 2>&1
 
 # Exiting
 exit $?


### PR DESCRIPTION
Опечатка в названии переменной, из-за чего значение переменной не подставлялось