### PR TITLE
Put tmpdir of backup at /tmp

### DIFF
--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -78,7 +78,7 @@ while [ "$la" -ge "$BACKUP_LA_LIMIT" ]; do
 done
 
 # Creating temporary directory
-tmpdir=$(mktemp -p $BACKUP -d)
+tmpdir=$(mktemp -d)
 if [ "$?" -ne 0 ]; then
     echo "Can't create tmp dir $tmpdir" | $send_mail -s "$subj" $email
     echo "Error: can't create tmp dir"


### PR DESCRIPTION
In case of local backup store at NFS/SMBFS/FUSE, etc. directories which aimed to backup the data in another server, putting temp data in a tmpdir inside the NFS/SMBFS/FUSE directory is extremely slow if the connect is a remote one. Especially when multiple backup run at the same time, creating a tmpdir may take minutes.

I use the above setup. I got lots of "backup failed" notice with reason: Can't create tmp dir. In fact the filesystem did create a tmpdir. So I launched multiple mktemp command at the same time and had a test, some of them returned error:

> mktemp: failed to create directory via template ‘/mnt/remote-backup/vesta/tmp.XXXXXXXXXX’: No such file or directory

Others took 30s to finish. So I believe it's better to store the temp backup file at /tmp.