### PR TITLE
Fix for the ftp user name prefix corruption

### DIFF
--- a/web/js/pages/add.web.js
+++ b/web/js/pages/add.web.js
@@ -3,11 +3,11 @@ App.Actions.WEB.update_ftp_username_hint = function(elm, hint) {
         $(elm).parent().find('.hint').html('');
     }
 
-    //hint = hint.replace(/[^\w\d]/gi, '');
-
     if (hint.indexOf(GLOBAL.FTP_USER_PREFIX) == 0) {
         hint = hint.slice(GLOBAL.FTP_USER_PREFIX.length, hint.length);
     }
+    hint = hint.replace(/[^\w\d]/gi, '');
+
     $(elm).parent().find('.v-ftp-user').val(hint);
     $(elm).parent().find('.hint').text(GLOBAL.FTP_USER_PREFIX + hint);
 }

--- a/web/js/pages/edit.web.js
+++ b/web/js/pages/edit.web.js
@@ -3,11 +3,11 @@ App.Actions.WEB.update_ftp_username_hint = function(elm, hint) {
         $(elm).parent().find('.hint').html('');
     }
 
-    //hint = hint.replace(/[^\w\d]/gi, '');
-
     if (hint.indexOf(GLOBAL.FTP_USER_PREFIX) == 0) {
         hint = hint.slice(GLOBAL.FTP_USER_PREFIX.length, hint.length);
     }
+    hint = hint.replace(/[^\w\d]/gi, '');
+
     $(elm).parent().find('.v-ftp-user').val(hint);
     $(elm).parent().find('.hint').text(GLOBAL.FTP_USER_PREFIX + hint);
 }


### PR DESCRIPTION
Proper fix for the prefix corruption (for user names with non-alphanumeric characters)
and keep the prevention of addition of ftp user names with non-alphanumeric characters as it was intended initially