### PR TITLE
Fix Undefined Var & Require $_POST['cmd'].

### DIFF
--- a/web/api/index.php
+++ b/web/api/index.php
@@ -32,6 +32,17 @@ if (isset($_POST['user']) || isset($_POST['hash'])) {
         exit;
     }
     
+    // Define the command to use
+    if (isset($_POST['cmd']))
+    {
+        $cmd = escapeshellarg($_POST['cmd']);
+    } else
+    {
+        // If there's no command, just exit.
+        echo 'No command specified.';
+        exit;
+    }
+    
     // Prepare for iteration
     $args = [];
     $i = 0;


### PR DESCRIPTION
I fixed an undefined variable in my past commit, and also enabled the requirement for the `cmd` POST field.