### PR TITLE
Quick and dirty hack to make history log dates correct

### DIFF
--- a/func/main.sh
+++ b/func/main.sh
@@ -76,7 +76,7 @@ log_history() {
 
     curr_str=$(grep "ID=" $log | cut -f 2 -d \' | sort -n | tail -n1)
     id="$((curr_str +1))"
-    echo "ID='$id' DATE='$DATE' TIME='$TIME' CMD='$cmd' UNDO='$undo'" >> $log
+    echo "ID='$id' DATE='$(date +%F)' TIME='$(date +%T)' CMD='$cmd' UNDO='$undo'" >> $log
 }
 
 # Result checker


### PR DESCRIPTION
Global DATE/TIME variables are often overwritten by functions that uses 'eval'. This makes history log entries dates incorrect. This is a quick&dirty solution to this problem. In a long run it would be wise to prefix global variables in some way or use eval calls in subshells.