### PR TITLE
Fix for domain template change if SSL is in use

### DIFF
--- a/bin/v-change-web-domain-tpl
+++ b/bin/v-change-web-domain-tpl
@@ -61,9 +61,10 @@ fi
 
 # Defining variables for new vhost config
 upd_web_domain_values
-tpl_file="$WEBTPL/$WEB_SYSTEM/$WEB_BACKEND/$template.tpl"
 
 # Adding domain to the web conf
+conf="$HOMEDIR/$user/conf/web/$WEB_SYSTEM.conf"
+tpl_file="$WEBTPL/$WEB_SYSTEM/$WEB_BACKEND/$template.tpl"
 add_web_config
 
 # Running template trigger


### PR DESCRIPTION
If SSL is in use, template change writes domain configuration to a wrong file.