### PR TITLE
Allow to disable the default 'admin' account password and use another system account to login as the 'admin'

### DIFF
--- a/bin/v-check-user-admin
+++ b/bin/v-check-user-admin
@@ -1,0 +1,32 @@
+#!/bin/bash
+# info: check is user an admin user
+# options: USER
+#
+# The function checks is a user an admin user
+
+user=$1
+
+# Checking arguments
+if [ -z "$user" ]; then
+    echo "Usage: USER"
+    exit 1
+fi
+
+if [ "$user" = "root" ]; then
+    exit
+fi
+
+# Checking user groups
+members=$(grep "^admin:" /etc/group | cut -f 4 -d :|sed 's/,/ /g')
+if [ -z "$members" ]; then
+    exit 1
+fi
+
+for member in $members; do
+    if [ "$member" = "$user" ]; then
+        exit
+    fi
+done
+
+# Exiting
+exit 1

--- a/bin/v-check-user-password
+++ b/bin/v-check-user-password
@@ -27,7 +27,7 @@ check_args '2' "$#" 'USER PASSWORD'
 validate_format 'user'
 
 # Checking user
-if [ ! -d "$VESTA/data/users/$user" ] && [ "$user" != 'root' ]; then
+if [ ! -d "$VESTA/data/users/$user" ] && ! $BIN/v-check-user-admin $user; then
     echo "Error: password missmatch"
     echo "$DATE $TIME $user $ip failed to login" >> $VESTA/log/auth.log
     exit 9

--- a/web/login/index.php
+++ b/web/login/index.php
@@ -53,11 +53,13 @@ if (isset($_POST['user']) && isset($_POST['password'])) {
     // Check API answer
     if ( $return_var > 0 ) {
         $ERROR = "<a class=\"error\">".__('Invalid username or password')."</a>";
-
     } else {
+        // Check is user an admin user
+        exec (VESTA_CMD . "v-check-user-admin ".$v_user, $output, $return_var);
+        unset($output);
 
-        // Make root admin user
-        if ($_POST['user'] == 'root') $v_user = 'admin';
+        // Check API answer
+        if ( $return_var == 0 ) $v_user = 'admin';
 
         // Get user speciefic parameters
         exec (VESTA_CMD . "v-list-user ".$v_user." json", $output, $return_var);


### PR DESCRIPTION
This patch is a bit controversial, but it doesn't break anything and allows to increase security a bit. It's now possible to disable 'admin' account and use another system account as 'admin' login. To do this you need to do two things. Add designated system account to the admin group (usermod -a -G admin account_name) and disable admin password (passwd -l admin). Works for web interface and API calls.