### PR TITLE
Nginx SSL config fix

### DIFF
--- a/bin/v-add-web-domain-ssl
+++ b/bin/v-add-web-domain-ssl
@@ -93,7 +93,7 @@ fi
 # Checking web config
 web_conf="/etc/$WEB_SYSTEM/conf.d/vesta.conf"
 if [ -z "$(grep "$conf" $web_conf)" ]; then
-    echo "Include $conf" >> $web_conf
+    echo "include $conf;" >> $web_conf
 fi
 
 # Checking proxy


### PR DESCRIPTION
Upon adding an SSL host a malformed NGINX config is created. 

This happens in the file: /etc/nginx/conf.d/vesta.conf:
````
include /home/client1/conf/web/nginx.conf;
Include /home/client1/conf/web/snginx.conf
include /home/client2/conf/web/nginx.conf;
Include /home/client2/conf/web/snginx.conf
````
Please notice the capitalized Include and the lack of a semicolon at the end of the SSL websites.

By using this patch this will be fixed.
Using this patch the config will no longer be malformed.