### PR TITLE
fix dokuwiki nginx template

### DIFF
--- a/bin/v-add-web-domain-ssl
+++ b/bin/v-add-web-domain-ssl
@@ -90,10 +90,14 @@ if [ -x $WEBTPL/$WEB_SYSTEM/$WEB_BACKEND/$template.sh ]; then
         $user $domain $ip $HOMEDIR $sdocroot
 fi
 
-# Checking web config
+# Checking web config include
 web_conf="/etc/$WEB_SYSTEM/conf.d/vesta.conf"
-if [ -z "$(grep "$conf" $web_conf)" ]; then
+web_include=$(grep "$conf" $web_conf )
+if [ -z "$web_include" ] && [ "$WEB_SYSTEM" != 'nginx' ]; then
     echo "Include $conf" >> $web_conf
+fi
+if [ -z "$web_include" ] && [ "$WEB_SYSTEM" = 'nginx' ]; then
+    echo "include $conf;" >> $web_conf
 fi
 
 # Checking proxy

--- a/bin/v-add-web-domain-ssl
+++ b/bin/v-add-web-domain-ssl
@@ -90,14 +90,10 @@ if [ -x $WEBTPL/$WEB_SYSTEM/$WEB_BACKEND/$template.sh ]; then
         $user $domain $ip $HOMEDIR $sdocroot
 fi
 
-# Checking web config include
+# Checking web config
 web_conf="/etc/$WEB_SYSTEM/conf.d/vesta.conf"
-web_include=$(grep "$conf" $web_conf )
-if [ -z "$web_include" ] && [ "$WEB_SYSTEM" != 'nginx' ]; then
+if [ -z "$(grep "$conf" $web_conf)" ]; then
     echo "Include $conf" >> $web_conf
-fi
-if [ -z "$web_include" ] && [ "$WEB_SYSTEM" = 'nginx' ]; then
-    echo "include $conf;" >> $web_conf
 fi
 
 # Checking proxy

--- a/install/debian/7/templates/web/nginx/php5-fpm/dokuwiki.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/dokuwiki.stpl
@@ -32,7 +32,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/debian/7/templates/web/nginx/php5-fpm/dokuwiki.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/dokuwiki.tpl
@@ -28,7 +28,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/debian/8/templates/web/nginx/php5-fpm/dokuwiki.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/dokuwiki.stpl
@@ -32,7 +32,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/debian/8/templates/web/nginx/php5-fpm/dokuwiki.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/dokuwiki.tpl
@@ -28,7 +28,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/rhel/5/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -32,7 +32,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/rhel/5/templates/web/nginx/php-fpm/dokuwiki.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/dokuwiki.tpl
@@ -28,7 +28,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/rhel/6/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -32,7 +32,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/rhel/6/templates/web/nginx/php-fpm/dokuwiki.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/dokuwiki.tpl
@@ -28,7 +28,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/rhel/7/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -32,7 +32,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/rhel/7/templates/web/nginx/php-fpm/dokuwiki.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/dokuwiki.tpl
@@ -28,7 +28,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/ubuntu/12.04/templates/web/nginx/php5-fpm/dokuwiki.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php5-fpm/dokuwiki.stpl
@@ -32,7 +32,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/ubuntu/12.04/templates/web/nginx/php5-fpm/dokuwiki.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php5-fpm/dokuwiki.tpl
@@ -28,7 +28,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/ubuntu/12.10/templates/web/nginx/php5-fpm/dokuwiki.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php5-fpm/dokuwiki.stpl
@@ -32,7 +32,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/ubuntu/12.10/templates/web/nginx/php5-fpm/dokuwiki.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php5-fpm/dokuwiki.tpl
@@ -28,7 +28,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/ubuntu/13.04/templates/web/nginx/php5-fpm/dokuwiki.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php5-fpm/dokuwiki.stpl
@@ -32,7 +32,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/ubuntu/13.04/templates/web/nginx/php5-fpm/dokuwiki.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php5-fpm/dokuwiki.tpl
@@ -28,7 +28,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/ubuntu/13.10/templates/web/nginx/php5-fpm/dokuwiki.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php5-fpm/dokuwiki.stpl
@@ -32,7 +32,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/ubuntu/13.10/templates/web/nginx/php5-fpm/dokuwiki.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php5-fpm/dokuwiki.tpl
@@ -28,7 +28,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/ubuntu/14.04/templates/web/nginx/php5-fpm/dokuwiki.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php5-fpm/dokuwiki.stpl
@@ -32,7 +32,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/ubuntu/14.04/templates/web/nginx/php5-fpm/dokuwiki.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php5-fpm/dokuwiki.tpl
@@ -28,7 +28,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/ubuntu/14.10/templates/web/nginx/php5-fpm/dokuwiki.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php5-fpm/dokuwiki.stpl
@@ -32,7 +32,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/ubuntu/14.10/templates/web/nginx/php5-fpm/dokuwiki.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php5-fpm/dokuwiki.tpl
@@ -28,7 +28,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/ubuntu/15.04/templates/web/nginx/php5-fpm/dokuwiki.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php5-fpm/dokuwiki.stpl
@@ -32,7 +32,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/ubuntu/15.04/templates/web/nginx/php5-fpm/dokuwiki.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php5-fpm/dokuwiki.tpl
@@ -28,7 +28,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/ubuntu/15.10/templates/web/nginx/php5-fpm/dokuwiki.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php5-fpm/dokuwiki.stpl
@@ -32,7 +32,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 

--- a/install/ubuntu/15.10/templates/web/nginx/php5-fpm/dokuwiki.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php5-fpm/dokuwiki.tpl
@@ -28,7 +28,7 @@ server {
         }
     }
 
-    location ^~ /lib/ {
+    location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
         expires 30d;
     }
 


### PR DESCRIPTION
The new dokuwiki template incorporates the lib location directive from https://www.nginx.com/resources/wiki/start/topics/recipes/dokuwiki/ which lets the PHP scripts inside lib/exe run. Else it'd just add an expire header to them and serve them as downloadable file.