### PR TITLE
Stricter Permissions

### DIFF
--- a/bin/v-add-user
+++ b/bin/v-add-user
@@ -67,10 +67,13 @@ echo "$user:$password" | /usr/sbin/chpasswd
 mkdir $HOMEDIR/$user/conf
 
 if [ ! -z "$WEB_SYSTEM" ]; then
+    nginxuser=$(ps -eo user,comm|grep nginx|uniq|grep -v "root"|awk '{ print $1}')
     mkdir $HOMEDIR/$user/conf/web $HOMEDIR/$user/web $HOMEDIR/$user/tmp
-    chmod 751 $HOMEDIR/$user/conf/web $HOMEDIR/$user/web
-    chmod 771 $HOMEDIR/$user/tmp
-    chown $user:$user $HOMEDIR/$user/web $HOMEDIR/$user/tmp
+    chmod 751 $HOMEDIR/$user/conf/web 
+    chmod 710 $HOMEDIR/$user/web
+    chmod 700 $HOMEDIR/$user/tmp
+    chown $user:$nginxuser $HOMEDIR/$user/web 
+    chown $user:$user $HOMEDIR/$user/tmp
 fi
 
 if [ ! -z "$MAIL_SYSTEM" ]; then


### PR DESCRIPTION
The current setup allows any user on the system to read other users web files as long as they know the path, the only users which should  be allow to access $HOMEDIR/$user/web is owner of sites and nginx user to be able to serve static files.

I also locked down access $HOMEDIR/$user/tmp to the user, its gets used in the hosting template for tmp files, i don't see why another user would need access to it as apache runs as the user.