### PR TITLE
Fix bug when try exclude domain whit 0 on name from backup.

### DIFF
--- a/bin/v-update-user-backup-exclusions
+++ b/bin/v-update-user-backup-exclusions
@@ -26,7 +26,7 @@ is_file_available() {
 }
 
 is_file_valid() {
-    exclude="[!$#&;()\]"
+    exclude="[!#&$;()\]"
     vcontent=$(cat $vfile)
     if [[ "$vcontent" =~ $exclude ]]; then
         echo "Error: invalid characters in the exlusion list"


### PR DESCRIPTION
It read arguments, so convert $# in a 0.

So cant explain it in english but is only a mistake when you type it, may you can quote it and use scape but if you change position of character you get fixed .