### PR TITLE
Handle Crypt (DES) passwords

### DIFF
--- a/bin/v-check-user-password
+++ b/bin/v-check-user-password
@@ -49,13 +49,24 @@ fi
 #----------------------------------------------------------#
 
 # Parsing user's salt
-shadow=$(grep "^$user:" /etc/shadow)
-salt=$(echo "$shadow" |cut -f 3 -d \$)
-method=$(echo "$shadow" |cut -f 2 -d \$)
-if [ "$method" -eq '1' ]; then
-    method='md5'
+shadow=$(grep "^$user:" /etc/shadow | cut -f 2 -d :)
+
+if echo "$shadow" | grep -qE '^\$[0-9a-z]+\$[^\$]+\$'
+then
+    salt=$(echo "$shadow" |cut -f 3 -d \$)
+    method=$(echo "$shadow" |cut -f 2 -d \$)
+    if [ "$method" -eq '1' ]; then
+        method='md5'
+    elif [ "$method" -eq '6' ]; then
+        method='sha-512'
+    else
+        echo "Error: password missmatch"
+        echo "$DATE $TIME $user $ip failed to login" >> $VESTA/log/auth.log
+        exit 9
+    fi
 else
-    method='sha-512'
+    salt=${shadow:0:2}
+    method='des'
 fi
 
 if [ -z "$salt" ]; then
@@ -64,7 +75,7 @@ if [ -z "$salt" ]; then
     exit 9
 fi
 
-# Generating SHA-512
+# Generating hash
 hash=$($BIN/v-generate-password-hash $method $salt <<< $password)
 if [[ -z "$hash" ]]; then
     echo "Error: password missmatch"

--- a/bin/v-generate-password-hash
+++ b/bin/v-generate-password-hash
@@ -37,5 +37,10 @@ if ($crypt == 'htpasswd' ) {
     $hash = crypt($password, base64_encode($password));
 }
 
+// Generating DES hash
+if ($crypt == 'des' ) {
+    $hash = crypt($password, $salt);
+}
+
 // Printing result
 echo $hash . "\n";


### PR DESCRIPTION
Although DES passwords are an old thing in the UNIX world and are now considered as weak, it can be useful to support them.

In my case I have to migrate users to Vesta from a system that uses crypt (DES) as the password hashing algorithm. Supporting this hashing method in Vesta is the only way for the users not to have to reset their password as a side effect of the migration.

Obviously, if a user change its password after the migration, it will be hashed using SHA-512.