### PR TITLE
Fix OS version in vst-install-debian.sh

### DIFF
--- a/install/vst-install-debian.sh
+++ b/install/vst-install-debian.sh
@@ -13,7 +13,7 @@ VERSION='debian'
 memory=$(grep 'MemTotal' /proc/meminfo |tr ' ' '\n' |grep [0-9])
 arch=$(uname -i)
 os='debian'
-release=$(cat /etc/issue|grep -o [0-9]|head -n1)
+release=$(cat /etc/debian_version|grep -o [0-9]|head -n1)
 codename="$(cat /etc/os-release |grep VERSION= |cut -f 2 -d \(|cut -f 1 -d \))"
 vestacp="http://$CHOST/$VERSION/$release"
 


### PR DESCRIPTION
This change will fix OS version detection in Debian in some installs like OVH default installs
