### PR TITLE
improved regular expression in v-backup-user file

### DIFF
--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -479,7 +479,7 @@ if [ "$USER" != '*' ]; then
     set -f
     i=0
 
-    for udir in $(ls -a |egrep -v "conf|web|dns|mail|^\.\.$|^\.$"); do
+    for udir in $(ls -a |egrep -v "^conf$|^web$|^dns$|^mail$|^\.\.$|^\.$"); do
         exclusion=$(echo "$USER" |tr ',' '\n' |grep "^$udir$")
         if [ -z "$exclusion" ]; then
             ((i ++))


### PR DESCRIPTION
The regular expression now uses exact match of a folder/file name.
With the previous version, some files were ignored during the backup process(for example .gitconfig, because it contains "conf").