### PR TITLE
Update edit_package.html

### DIFF
--- a/web/templates/admin/edit_package.html
+++ b/web/templates/admin/edit_package.html
@@ -22,12 +22,7 @@
 
     <div class="l-center">
       <?php
-        $back = getenv("HTTP_REFERER");
-        if (empty($back)) {
-          $back = "location.href='/list/package/'";
-        } else {
-          $back = "location.href='".$back."'";
-        }
+        $back = "location.href='/list/package/'";
       ?>
         <form id="vstobjects" name="v_edit_package" method="post"  class="<?=$v_status?>">
             <input type="hidden" name="token" value="<?=$_SESSION['token']?>" />


### PR DESCRIPTION
After save the package, back button link is referer to https://domain/list/package/?package={package_name}
i think we dont need this. Back button will alway go to /list/package/ .... 
 CMIIW ....