### PR TITLE
no-php.tpl # comment replaced with ; comment

### DIFF
--- a/install/debian/7/templates/web/php5-fpm/no-php.tpl
+++ b/install/debian/7/templates/web/php5-fpm/no-php.tpl
@@ -1,13 +1,13 @@
-#[%backend%]
-#user = %user%
-#group = %user%
-#listen = /dev/null
+;[%backend%]
+;user = %user%
+;group = %user%
+;listen = /dev/null
 
-#listen.owner = %user%
-#listen.group = nginx
+;listen.owner = %user%
+;listen.group = nginx
 
-#pm = dynamic
-#pm.max_children = 50
-#pm.start_servers = 3
-#pm.min_spare_servers = 2
-#pm.max_spare_servers = 10
+;pm = dynamic
+;pm.max_children = 50
+;pm.start_servers = 3
+;pm.min_spare_servers = 2
+;pm.max_spare_servers = 10

--- a/install/debian/8/templates/web/php5-fpm/no-php.tpl
+++ b/install/debian/8/templates/web/php5-fpm/no-php.tpl
@@ -1,13 +1,13 @@
-#[%backend%]
-#user = %user%
-#group = %user%
-#listen = /dev/null
+;[%backend%]
+;user = %user%
+;group = %user%
+;listen = /dev/null
 
-#listen.owner = %user%
-#listen.group = nginx
+;listen.owner = %user%
+;listen.group = nginx
 
-#pm = dynamic
-#pm.max_children = 50
-#pm.start_servers = 3
-#pm.min_spare_servers = 2
-#pm.max_spare_servers = 10
+;pm = dynamic
+;pm.max_children = 50
+;pm.start_servers = 3
+;pm.min_spare_servers = 2
+;pm.max_spare_servers = 10

--- a/install/rhel/5/templates/web/php-fpm/no-php.tpl
+++ b/install/rhel/5/templates/web/php-fpm/no-php.tpl
@@ -1,13 +1,13 @@
-#[%backend%]
-#user = %user%
-#group = %user%
-#listen = /dev/null
+;[%backend%]
+;user = %user%
+;group = %user%
+;listen = /dev/null
 
-#listen.owner = %user%
-#listen.group = nginx
+;listen.owner = %user%
+;listen.group = nginx
 
-#pm = dynamic
-#pm.max_children = 50
-#pm.start_servers = 3
-#pm.min_spare_servers = 2
-#pm.max_spare_servers = 10
+;pm = dynamic
+;pm.max_children = 50
+;pm.start_servers = 3
+;pm.min_spare_servers = 2
+;pm.max_spare_servers = 10

--- a/install/rhel/6/templates/web/php-fpm/no-php.tpl
+++ b/install/rhel/6/templates/web/php-fpm/no-php.tpl
@@ -1,13 +1,13 @@
-#[%backend%]
-#user = %user%
-#group = %user%
-#listen = /dev/null
+;[%backend%]
+;user = %user%
+;group = %user%
+;listen = /dev/null
 
-#listen.owner = %user%
-#listen.group = nginx
+;listen.owner = %user%
+;listen.group = nginx
 
-#pm = dynamic
-#pm.max_children = 50
-#pm.start_servers = 3
-#pm.min_spare_servers = 2
-#pm.max_spare_servers = 10
+;pm = dynamic
+;pm.max_children = 50
+;pm.start_servers = 3
+;pm.min_spare_servers = 2
+;pm.max_spare_servers = 10

--- a/install/rhel/7/templates/web/php-fpm/no-php.tpl
+++ b/install/rhel/7/templates/web/php-fpm/no-php.tpl
@@ -1,13 +1,13 @@
-#[%backend%]
-#user = %user%
-#group = %user%
-#listen = /dev/null
+;[%backend%]
+;user = %user%
+;group = %user%
+;listen = /dev/null
 
-#listen.owner = %user%
-#listen.group = nginx
+;listen.owner = %user%
+;listen.group = nginx
 
-#pm = dynamic
-#pm.max_children = 50
-#pm.start_servers = 3
-#pm.min_spare_servers = 2
-#pm.max_spare_servers = 10
+;pm = dynamic
+;pm.max_children = 50
+;pm.start_servers = 3
+;pm.min_spare_servers = 2
+;pm.max_spare_servers = 10

--- a/install/ubuntu/12.04/templates/web/php5-fpm/no-php.tpl
+++ b/install/ubuntu/12.04/templates/web/php5-fpm/no-php.tpl
@@ -1,13 +1,13 @@
-#[%backend%]
-#user = %user%
-#group = %user%
-#listen = /dev/null
+;[%backend%]
+;user = %user%
+;group = %user%
+;listen = /dev/null
 
-#listen.owner = %user%
-#listen.group = nginx
+;listen.owner = %user%
+;listen.group = nginx
 
-#pm = dynamic
-#pm.max_children = 50
-#pm.start_servers = 3
-#pm.min_spare_servers = 2
-#pm.max_spare_servers = 10
+;pm = dynamic
+;pm.max_children = 50
+;pm.start_servers = 3
+;pm.min_spare_servers = 2
+;pm.max_spare_servers = 10

--- a/install/ubuntu/12.10/templates/web/php5-fpm/no-php.tpl
+++ b/install/ubuntu/12.10/templates/web/php5-fpm/no-php.tpl
@@ -1,13 +1,13 @@
-#[%backend%]
-#user = %user%
-#group = %user%
-#listen = /dev/null
+;[%backend%]
+;user = %user%
+;group = %user%
+;listen = /dev/null
 
-#listen.owner = %user%
-#listen.group = nginx
+;listen.owner = %user%
+;listen.group = nginx
 
-#pm = dynamic
-#pm.max_children = 50
-#pm.start_servers = 3
-#pm.min_spare_servers = 2
-#pm.max_spare_servers = 10
+;pm = dynamic
+;pm.max_children = 50
+;pm.start_servers = 3
+;pm.min_spare_servers = 2
+;pm.max_spare_servers = 10

--- a/install/ubuntu/13.04/templates/web/php5-fpm/no-php.tpl
+++ b/install/ubuntu/13.04/templates/web/php5-fpm/no-php.tpl
@@ -1,13 +1,13 @@
-#[%backend%]
-#user = %user%
-#group = %user%
-#listen = /dev/null
+;[%backend%]
+;user = %user%
+;group = %user%
+;listen = /dev/null
 
-#listen.owner = %user%
-#listen.group = nginx
+;listen.owner = %user%
+;listen.group = nginx
 
-#pm = dynamic
-#pm.max_children = 50
-#pm.start_servers = 3
-#pm.min_spare_servers = 2
-#pm.max_spare_servers = 10
+;pm = dynamic
+;pm.max_children = 50
+;pm.start_servers = 3
+;pm.min_spare_servers = 2
+;pm.max_spare_servers = 10

--- a/install/ubuntu/13.10/templates/web/php5-fpm/no-php.tpl
+++ b/install/ubuntu/13.10/templates/web/php5-fpm/no-php.tpl
@@ -1,13 +1,13 @@
-#[%backend%]
-#user = %user%
-#group = %user%
-#listen = /dev/null
+;[%backend%]
+;user = %user%
+;group = %user%
+;listen = /dev/null
 
-#listen.owner = %user%
-#listen.group = nginx
+;listen.owner = %user%
+;listen.group = nginx
 
-#pm = dynamic
-#pm.max_children = 50
-#pm.start_servers = 3
-#pm.min_spare_servers = 2
-#pm.max_spare_servers = 10
+;pm = dynamic
+;pm.max_children = 50
+;pm.start_servers = 3
+;pm.min_spare_servers = 2
+;pm.max_spare_servers = 10

--- a/install/ubuntu/14.04/templates/web/php5-fpm/no-php.tpl
+++ b/install/ubuntu/14.04/templates/web/php5-fpm/no-php.tpl
@@ -1,13 +1,13 @@
-#[%backend%]
-#user = %user%
-#group = %user%
-#listen = /dev/null
+;[%backend%]
+;user = %user%
+;group = %user%
+;listen = /dev/null
 
-#listen.owner = %user%
-#listen.group = nginx
+;listen.owner = %user%
+;listen.group = nginx
 
-#pm = dynamic
-#pm.max_children = 50
-#pm.start_servers = 3
-#pm.min_spare_servers = 2
-#pm.max_spare_servers = 10
+;pm = dynamic
+;pm.max_children = 50
+;pm.start_servers = 3
+;pm.min_spare_servers = 2
+;pm.max_spare_servers = 10

--- a/install/ubuntu/14.10/templates/web/php5-fpm/no-php.tpl
+++ b/install/ubuntu/14.10/templates/web/php5-fpm/no-php.tpl
@@ -1,13 +1,13 @@
-#[%backend%]
-#user = %user%
-#group = %user%
-#listen = /dev/null
+;[%backend%]
+;user = %user%
+;group = %user%
+;listen = /dev/null
 
-#listen.owner = %user%
-#listen.group = nginx
+;listen.owner = %user%
+;listen.group = nginx
 
-#pm = dynamic
-#pm.max_children = 50
-#pm.start_servers = 3
-#pm.min_spare_servers = 2
-#pm.max_spare_servers = 10
+;pm = dynamic
+;pm.max_children = 50
+;pm.start_servers = 3
+;pm.min_spare_servers = 2
+;pm.max_spare_servers = 10

--- a/install/ubuntu/15.04/templates/web/php5-fpm/no-php.tpl
+++ b/install/ubuntu/15.04/templates/web/php5-fpm/no-php.tpl
@@ -1,13 +1,13 @@
-#[%backend%]
-#user = %user%
-#group = %user%
-#listen = /dev/null
+;[%backend%]
+;user = %user%
+;group = %user%
+;listen = /dev/null
 
-#listen.owner = %user%
-#listen.group = nginx
+;listen.owner = %user%
+;listen.group = nginx
 
-#pm = dynamic
-#pm.max_children = 50
-#pm.start_servers = 3
-#pm.min_spare_servers = 2
-#pm.max_spare_servers = 10
+;pm = dynamic
+;pm.max_children = 50
+;pm.start_servers = 3
+;pm.min_spare_servers = 2
+;pm.max_spare_servers = 10

--- a/install/ubuntu/15.10/templates/web/php5-fpm/no-php.tpl
+++ b/install/ubuntu/15.10/templates/web/php5-fpm/no-php.tpl
@@ -1,13 +1,13 @@
-#[%backend%]
-#user = %user%
-#group = %user%
-#listen = /dev/null
+;[%backend%]
+;user = %user%
+;group = %user%
+;listen = /dev/null
 
-#listen.owner = %user%
-#listen.group = nginx
+;listen.owner = %user%
+;listen.group = nginx
 
-#pm = dynamic
-#pm.max_children = 50
-#pm.start_servers = 3
-#pm.min_spare_servers = 2
-#pm.max_spare_servers = 10
+;pm = dynamic
+;pm.max_children = 50
+;pm.start_servers = 3
+;pm.min_spare_servers = 2
+;pm.max_spare_servers = 10


### PR DESCRIPTION
Replaced the # in the no-php.tpl files with ; to make it compatible with PHP7.
Otherwise php-fpm breaks on restart if a site has no-php as a backend template.