### PR TITLE
backup download fix

### DIFF
--- a/web/download/backup/index.php
+++ b/web/download/backup/index.php
@@ -4,9 +4,10 @@ error_reporting(NULL);
 session_start();
 include($_SERVER['DOCUMENT_ROOT']."/inc/main.php");
 $backup = $_GET['backup'];
+$backup_full_path = "/home/backup/".$backup;
 
 // Check if the backup exists
-if (!file_exists($backup)) {
+if (!file_exists($backup_full_path)) {
     exit(0);
 }
 


### PR DESCRIPTION
backup download is broken as $_GET['backup'] contains only backup file name, not path.

This is dirty fix for this but file needs full refactoring IMHO.