### PR TITLE
Fix SSL config include on NGINX+PHP-FPM

### DIFF
--- a/bin/v-add-web-domain-ssl
+++ b/bin/v-add-web-domain-ssl
@@ -93,7 +93,11 @@ fi
 # Checking web config
 web_conf="/etc/$WEB_SYSTEM/conf.d/vesta.conf"
 if [ -z "$(grep "$conf" $web_conf)" ]; then
-    echo "Include $conf" >> $web_conf
+    if [ "$WEB_SYSTEM" = 'nginx' ]; then
+        echo "include $conf;" >> $web_conf
+    else
+        echo "Include $conf" >> $web_conf
+    fi
 fi
 
 # Checking proxy


### PR DESCRIPTION
Fixes error nginx: [emerg] unexpected end of file, expecting ";" or "}" in /etc/nginx/conf.d/vesta.conf after a SSL certificate is added on a NGINX+PHP-FPM system.