### PR TITLE
Update httpd templates

### DIFF
--- a/install/debian/7/templates/web/apache2/basedir.stpl
+++ b/install/debian/7/templates/web/apache2/basedir.stpl
@@ -18,7 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/debian/7/templates/web/apache2/basedir.tpl
+++ b/install/debian/7/templates/web/apache2/basedir.tpl
@@ -17,7 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/debian/7/templates/web/apache2/hosting.stpl
+++ b/install/debian/7/templates/web/apache2/hosting.stpl
@@ -21,7 +21,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/debian/7/templates/web/apache2/hosting.tpl
+++ b/install/debian/7/templates/web/apache2/hosting.tpl
@@ -21,7 +21,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/debian/8/templates/web/apache2/basedir.stpl
+++ b/install/debian/8/templates/web/apache2/basedir.stpl
@@ -18,7 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/debian/8/templates/web/apache2/basedir.tpl
+++ b/install/debian/8/templates/web/apache2/basedir.tpl
@@ -17,7 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/debian/8/templates/web/apache2/hosting.stpl
+++ b/install/debian/8/templates/web/apache2/hosting.stpl
@@ -21,7 +21,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/debian/8/templates/web/apache2/hosting.tpl
+++ b/install/debian/8/templates/web/apache2/hosting.tpl
@@ -20,7 +20,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/rhel/5/templates/web/httpd/basedir.stpl
+++ b/install/rhel/5/templates/web/httpd/basedir.stpl
@@ -18,7 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/5/templates/web/httpd/basedir.tpl
+++ b/install/rhel/5/templates/web/httpd/basedir.tpl
@@ -17,7 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/5/templates/web/httpd/hosting.stpl
+++ b/install/rhel/5/templates/web/httpd/hosting.stpl
@@ -21,7 +21,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/rhel/5/templates/web/httpd/hosting.tpl
+++ b/install/rhel/5/templates/web/httpd/hosting.tpl
@@ -20,7 +20,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/rhel/6/templates/web/httpd/basedir.stpl
+++ b/install/rhel/6/templates/web/httpd/basedir.stpl
@@ -18,7 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/6/templates/web/httpd/basedir.tpl
+++ b/install/rhel/6/templates/web/httpd/basedir.tpl
@@ -17,7 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/6/templates/web/httpd/hosting.stpl
+++ b/install/rhel/6/templates/web/httpd/hosting.stpl
@@ -21,7 +21,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/rhel/6/templates/web/httpd/hosting.tpl
+++ b/install/rhel/6/templates/web/httpd/hosting.tpl
@@ -20,7 +20,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/rhel/7/templates/web/httpd/basedir.stpl
+++ b/install/rhel/7/templates/web/httpd/basedir.stpl
@@ -18,7 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/7/templates/web/httpd/basedir.tpl
+++ b/install/rhel/7/templates/web/httpd/basedir.tpl
@@ -17,7 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/7/templates/web/httpd/hosting.stpl
+++ b/install/rhel/7/templates/web/httpd/hosting.stpl
@@ -21,7 +21,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/rhel/7/templates/web/httpd/hosting.tpl
+++ b/install/rhel/7/templates/web/httpd/hosting.tpl
@@ -20,7 +20,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/ubuntu/12.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/12.04/templates/web/apache2/basedir.stpl
@@ -18,7 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/12.04/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/12.04/templates/web/apache2/basedir.tpl
@@ -17,7 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/12.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/12.04/templates/web/apache2/hosting.stpl
@@ -21,7 +21,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/ubuntu/12.04/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/12.04/templates/web/apache2/hosting.tpl
@@ -20,7 +20,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/ubuntu/12.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/12.10/templates/web/apache2/basedir.stpl
@@ -18,7 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/12.10/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/12.10/templates/web/apache2/basedir.tpl
@@ -17,7 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/12.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/12.10/templates/web/apache2/hosting.stpl
@@ -21,7 +21,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/ubuntu/12.10/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/12.10/templates/web/apache2/hosting.tpl
@@ -20,7 +20,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/ubuntu/13.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/13.04/templates/web/apache2/basedir.stpl
@@ -18,7 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/13.04/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/13.04/templates/web/apache2/basedir.tpl
@@ -17,7 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/13.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/13.04/templates/web/apache2/hosting.stpl
@@ -21,7 +21,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/ubuntu/13.04/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/13.04/templates/web/apache2/hosting.tpl
@@ -20,7 +20,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/ubuntu/13.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/13.10/templates/web/apache2/basedir.stpl
@@ -18,7 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/13.10/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/13.10/templates/web/apache2/basedir.tpl
@@ -17,7 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/13.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/13.10/templates/web/apache2/hosting.stpl
@@ -21,7 +21,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/ubuntu/13.10/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/13.10/templates/web/apache2/hosting.tpl
@@ -20,7 +20,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/ubuntu/14.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/14.04/templates/web/apache2/basedir.stpl
@@ -18,7 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/14.04/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/14.04/templates/web/apache2/basedir.tpl
@@ -17,7 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/14.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/14.04/templates/web/apache2/hosting.stpl
@@ -21,7 +21,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/ubuntu/14.04/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/14.04/templates/web/apache2/hosting.tpl
@@ -20,7 +20,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/ubuntu/14.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/14.10/templates/web/apache2/basedir.stpl
@@ -18,7 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/14.10/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/14.10/templates/web/apache2/basedir.tpl
@@ -17,7 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/14.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/14.10/templates/web/apache2/hosting.stpl
@@ -21,7 +21,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/ubuntu/14.10/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/14.10/templates/web/apache2/hosting.tpl
@@ -20,7 +20,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/ubuntu/15.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/15.04/templates/web/apache2/basedir.stpl
@@ -18,7 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/15.04/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/15.04/templates/web/apache2/basedir.tpl
@@ -17,7 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/15.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/15.04/templates/web/apache2/hosting.stpl
@@ -21,7 +21,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/ubuntu/15.04/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/15.04/templates/web/apache2/hosting.tpl
@@ -20,7 +20,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/ubuntu/15.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/15.10/templates/web/apache2/basedir.stpl
@@ -18,7 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/15.10/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/15.10/templates/web/apache2/basedir.tpl
@@ -17,7 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/15.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/15.10/templates/web/apache2/hosting.stpl
@@ -21,7 +21,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp

--- a/install/ubuntu/15.10/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/15.10/templates/web/apache2/hosting.tpl
@@ -20,7 +20,7 @@
         php_admin_value memory_limit 32M
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
-        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain%"
+        php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp


### PR DESCRIPTION
Parameter %domain% may contain non-ASCII characters, use the %domain_idn% instead, when specifying sendmail Return-Path