### PR TITLE
Fix XSS in Password Reset

### DIFF
--- a/web/templates/reset_2.html
+++ b/web/templates/reset_2.html
@@ -21,7 +21,7 @@
                                             <tr>
                                                 <td>
                                                     <input type="hidden" name="action" value="confirm">
-                                                    <input type="hidden" name="user" value="<?php echo $_GET['user'];?>">
+                                                    <input type="hidden" name="user" value="<?=htmlentities($_GET['user'], ENT_QUOTES|ENT_HTML5)?>">
                                                     <input tabindex="1" type="text" size="20px" style="width:240px" name="code" class="vst-input">
                                                 </td>
                                             </tr>

--- a/web/templates/reset_3.html
+++ b/web/templates/reset_3.html
@@ -13,8 +13,8 @@
                                             <tr>
                                                 <td style="padding: 12px 0 0 2px;">
                                                     <input type="hidden" name="action" value="confirm" >
-                                                    <input type="hidden" name="user" value="<?php echo $_GET['user'];?>" >
-                                                    <input type="hidden" name="code" value="<?php echo $_GET['code'];?>" >
+                                                    <input type="hidden" name="user" value="<?=htmlentities($_GET['user'], ENT_QUOTES|ENT_HTML5)?>" >
+                                                    <input type="hidden" name="code" value="<?=htmlentities($_GET['code'], ENT_QUOTES|ENT_HTML5)?>" >
                                                     <?php print __('New Password');?>
                                                 </td>
                                             </tr>


### PR DESCRIPTION
As I wrote in the caption.

This doesn't seem to be so important because visitor is considered not to have something secret at that time.
However I think there is a need for a shorthand for `htmlentities` in order to escape strings easily.