### PR TITLE
External package file loading

### DIFF
--- a/bin/v-add-user-package
+++ b/bin/v-add-user-package
@@ -28,7 +28,7 @@ is_package_new() {
 }
 
 is_package_consistent() {
-    source $pkg_dir/$package.pkg
+    source <(curl -s $1)
     if [ "$WEB_DOMAINS" != 'unlimited' ]; then
         is_format_valid_int $WEB_DOMAINS 'WEB_DOMAINS'
     fi


### PR DESCRIPTION
I've been thinking a while about this API method and I think could be better to load the package from the "outside". Right now you need to transfer the file to the host before. I've not tried this proposal yet, but even knowing it's really risky I think it could be quite more practical.