### PR TITLE
Add TLSA Record Type to DNS Manager

### DIFF
--- a/func/main.sh
+++ b/func/main.sh
@@ -589,7 +589,7 @@ is_dbuser_format_valid() {
 
 # DNS record type validator
 is_dns_type_format_valid() {
-    known_dnstype='A,AAAA,NS,CNAME,MX,TXT,SRV,DNSKEY,KEY,IPSECKEY,PTR,SPF'
+    known_dnstype='A,AAAA,NS,CNAME,MX,TXT,SRV,DNSKEY,KEY,IPSECKEY,PTR,SPF,TLSA'
     if [ -z "$(echo $known_dnstype |grep -w $1)" ]; then
         check_result $E_INVALID "invalid dns record type format :: $1"
     fi

--- a/web/templates/admin/add_dns_rec.html
+++ b/web/templates/admin/add_dns_rec.html
@@ -80,6 +80,7 @@
                                         <option value="IPSECKEY" <?php if ($v_type == 'IPSECKEY') echo selected; ?>>IPSECKEY</option>
                                         <option value="PTR" <?php if ($v_type == 'PTR') echo selected; ?>>PTR</option>
                                         <option value="SPF" <?php if ($v_type == 'SPF') echo selected; ?>>SPF</option>
+                                        <option value="TLSA" <?php if ($v_type == 'TLSA') echo selected; ?>>TLSA</option>
                                     </select>
                                 </td>
                             </tr>


### PR DESCRIPTION
According to wikipedia(https://en.wikipedia.org/wiki/List_of_DNS_record_types) TLSA is : A record for DNS-based Authentication of Named Entities (DANE). RFC 6698 defines "The TLSA DNS resource record is used to associate a TLS server certificate or public key with the domain name where the record is found, thus forming a 'TLSA certificate association'".

You can use this for increase score in SSL testers.

a generator is here: https://www.huque.com/bin/gen_tlsa

Would be nice to have in panel.

Regards!