### PR TITLE
Removing AllowSupplementaryGroups from clamav.conf

### DIFF
--- a/install/debian/8/clamav/clamd.conf
+++ b/install/debian/8/clamav/clamd.conf
@@ -8,7 +8,7 @@ LocalSocketMode 666
 # TemporaryDirectory is not set to its default /tmp here to make overriding
 # the default with environment variables TMPDIR/TMP/TEMP possible
 User clamav
-AllowSupplementaryGroups true
+# AllowSupplementaryGroups true
 ScanMail true
 ScanArchive true
 ArchiveBlockEncrypted false


### PR DESCRIPTION
Option 'AllowSupplementaryGroups' is not allowed anymore on new version of ClamAV on Debian 8.
Reported as bug - https://bugs.vestacp.com/issues/279
Details - http://forum.vestacp.com/viewtopic.php?f=12&t=11884