### PR TITLE
Changing password_vesta_host to server hostname

### DIFF
--- a/install/vst-install-debian.sh
+++ b/install/vst-install-debian.sh
@@ -1069,6 +1069,7 @@ if [ "$exim" = 'yes' ] && [ "$mysql" = 'yes' ]; then
     mysql -e "CREATE DATABASE roundcube"
     mysql -e "GRANT ALL ON roundcube.* TO roundcube@localhost IDENTIFIED BY '$r'"
     sed -i "s/%password%/$r/g" /etc/roundcube/db.inc.php
+    sed -i "s/localhost/$servername/g" /etc/roundcube/plugins/password/config.inc.php
     mysql roundcube < /usr/share/dbconfig-common/data/roundcube/install/mysql
     chmod a+r /etc/roundcube/main.inc.php
     if [ "$release" -eq 8 ]; then


### PR DESCRIPTION
''Vesta Password Driver for Roundcube'' will try to make a HTTPS request to Vesta, in order to change mail password.
In /etc/roundcube/plugins/password/config.inc.php you have:
$rcmail_config['password_vesta_host'] = 'localhost';

That 'localhost' must be changed to server hostname, because HTTPS to localhost will not works if your server hostname is not 'localhost', because SSL certs are not for 'localhost' but for server hostname.

This line will change localhost to server hostname, and 'Vesta Password driver for Roundcube' will works.

Reported as a bug long time ago - https://forum.vestacp.com/viewtopic.php?f=12&t=10114&p=39648#p38630
See part of post after step 9.
In v16 you accepted my pull request for password driver, but that was just a partial fix, because it needs fix for hostname too.