### PR TITLE
Roundcube log permission fix

### DIFF
--- a/install/vst-install-debian.sh
+++ b/install/vst-install-debian.sh
@@ -1125,6 +1125,14 @@ check_result $? "can't create admin user"
 $VESTA/bin/v-change-user-shell admin bash
 $VESTA/bin/v-change-user-language admin $lang
 
+# RoundCube permissions fix
+if [ "$exim" = 'yes' ] && [ "$mysql" = 'yes' ]; then
+	if [ ! -d "/var/log/roundcube" ]; then
+		mkdir /var/log/roundcube
+	fi
+    chown admin:admin /var/log/roundcube
+fi
+
 # Configuring system ips
 $VESTA/bin/v-update-sys-ip
 


### PR DESCRIPTION
Roundcube is not able to write to /var/log/roundcube on Debian 8.
This is a fix for it.

Reported as a bug long time ago - https://forum.vestacp.com/viewtopic.php?f=12&t=10114&p=39648#p38630
See last line at this post.
In v16 you accepted my pull request for password driver, but that was just a partial fix, because it needs to fix log permissions too.

Now here is a fix for roundcube log permissions.