### PR TITLE
Fix for SMTP and IMAP hostname in add_mail_acc.html template

### DIFF
--- a/web/templates/admin/add_mail_acc.html
+++ b/web/templates/admin/add_mail_acc.html
@@ -132,6 +132,7 @@
             <td class="mail-infoblock-td">
                 <div class="mail-infoblock">
                 <table>
+                    <?php $uname_arr=posix_uname(); $hostname=$uname_arr['nodename']; ?>
                     <tr>
                         <td><?=__('Username')?>:</td>
                         <td><span id="v_account">william.cage</span>@<?=htmlentities($v_domain)?></td>
@@ -142,7 +143,7 @@
                     </tr>
                     <tr>
                         <td><?=__('IMAP hostname')?>:</td>
-                        <td><?=htmlentities($v_domain)?></td>
+                        <td><?=$hostname?></td>
                     </tr>
                     <tr>
                         <td><?=__('IMAP port')?>:</td>
@@ -158,7 +159,7 @@
                     </tr>
                     <tr>
                         <td><?=__('SMTP hostname')?></td>
-                        <td><?=htmlentities($v_domain)?></td>
+                        <td><?=$hostname?></td>
                     </tr>
                     <tr>
                         <td><?=__('SMTP port')?>:</td>


### PR DESCRIPTION
Dovecot and Exim4 is able to handle ONLY one TLS / SSL cert.
In most cases - it is a cert ONLY for server hostname.
So, if you point mail client to $v_domain for IMAP/SMTP TLS - mail client will popup a warning and it will say that certs are for server hostname - not for a domain that client added.

So, in most cases (in 99% percents) it is better to point mail client to server hostname - because in most cases Exim4 and Dovecot have a valid cert only for server hostname.