### PR TITLE
Fix for: /usr/local/vesta/func/db.sh: line 390: [: : integer expressi…

### DIFF
--- a/func/db.sh
+++ b/func/db.sh
@@ -387,7 +387,7 @@ get_mysql_disk_usage() {
     query="SELECT SUM( data_length + index_length ) / 1024 / 1024 \"Size\"
         FROM information_schema.TABLES WHERE table_schema='$database'"
     usage=$(mysql_query "$query" |tail -n1)
-    if [ "$usage" == 'NULL' ] || [ "${usage:0:1}" -eq '0' ]; then
+    if [ "$usage" == '' ] || [ "$usage" == 'NULL' ] || [ "${usage:0:1}" -eq '0' ]; then
         usage=1
     fi
     export LC_ALL=C


### PR DESCRIPTION
…on expected

Every night cron is sending email with subject: Cron <admin@host> sudo /usr/local/vesta/bin/v-update-sys-queue disk
And content of that email is: /usr/local/vesta/func/db.sh: line 390: [: : integer expression expected

This is a fix for that bug.

I guess mysql for some databases returns empty string for DB size, so this will handle that case.