### PR TITLE
400 error from account registration.

### DIFF
--- a/bin/v-add-letsencrypt-user
+++ b/bin/v-add-letsencrypt-user
@@ -41,7 +41,7 @@ fi
 #----------------------------------------------------------#
 
 api='https://acme-v01.api.letsencrypt.org'
-agreement='https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf'
+agreement='https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf'
 if [ -z "$email" ]; then
     email=$(get_user_value '$CONTACT')
 fi


### PR DESCRIPTION
i take this error v-add-letsencrypt-user "Error: LetsEncrypt account registration 400". 

Datailed answer part : 
{
  "type": "urn:acme:error:malformed",
  "detail": "Provided agreement URL [https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf] does not match current agreement URL [https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf]",
  "status": 400
}
