### PR TITLE
Fix for: Warning: purging the environment. Suggested action: use keep…

### DIFF
--- a/install/debian/8/exim/exim4.conf.template
+++ b/install/debian/8/exim/exim4.conf.template
@@ -8,6 +8,9 @@
 #SPAM_SCORE = 50
 #CLAMD =  yes
 
+add_environment=<; PATH=/bin:/usr/bin
+keep_environment=
+
 domainlist local_domains = dsearch;/etc/exim4/domains/
 domainlist relay_to_domains = dsearch;/etc/exim4/domains/
 hostlist relay_from_hosts = 127.0.0.1


### PR DESCRIPTION
…_environment.

Well known Exim4 issue.
Skurudo gave a solution - https://forum.vestacp.com/viewtopic.php?t=11220#p42605

And, btw, you could think about adding:
disable_ipv6=true
... because GMail and many others mail servers consider sending from ipv6 as spammy email.
(very stupid logic, but it's simply true, if you are sending from ipv6 GMail will mark it as SPAM 100%)
I'm not commiting this, I'll leave to you about this.
In this commit I'm just fixing well known issue with keep_enviroment.