### PR TITLE
Added dealings for method sys_get_temp_dir

### DIFF
--- a/install/debian/7/templates/web/apache2/basedir.stpl
+++ b/install/debian/7/templates/web/apache2/basedir.stpl
@@ -19,6 +19,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/debian/7/templates/web/apache2/basedir.tpl
+++ b/install/debian/7/templates/web/apache2/basedir.tpl
@@ -18,6 +18,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/debian/7/templates/web/apache2/default.stpl
+++ b/install/debian/7/templates/web/apache2/default.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/debian/7/templates/web/apache2/default.tpl
+++ b/install/debian/7/templates/web/apache2/default.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/debian/7/templates/web/apache2/hosting.stpl
+++ b/install/debian/7/templates/web/apache2/hosting.stpl
@@ -25,6 +25,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/debian/7/templates/web/apache2/hosting.tpl
+++ b/install/debian/7/templates/web/apache2/hosting.tpl
@@ -25,6 +25,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/debian/7/templates/web/apache2/magento.stpl
+++ b/install/debian/7/templates/web/apache2/magento.stpl
@@ -1,0 +1,44 @@
+<VirtualHost %ip%:%web_ssl_port%>
+
+    ServerName %domain_idn%
+    %alias_string%
+    ServerAdmin %email%
+    DocumentRoot %sdocroot%
+    ScriptAlias /cgi-bin/ %home%/%user%/web/%domain%/cgi-bin/
+    Alias /vstats/ %home%/%user%/web/%domain%/stats/
+    Alias /error/ %home%/%user%/web/%domain%/document_errors/
+    #SuexecUserGroup %user% %group%
+    CustomLog /var/log/%web_system%/domains/%domain%.bytes bytes
+    CustomLog /var/log/%web_system%/domains/%domain%.log combined
+    ErrorLog /var/log/%web_system%/domains/%domain%.error.log
+    <Directory %sdocroot%>
+        AllowOverride All
+        SSLRequireSSL
+        Options +Includes -Indexes +ExecCGI
+        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/etc/pki:/etc/ssl:/usr/local:/usr/ssl:/opt/local:/usr/local:/usr/share/ssl
+        php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
+    </Directory>
+    <Directory %home%/%user%/web/%domain%/stats>
+        AllowOverride All
+    </Directory>
+    SSLEngine on
+    SSLVerifyClient none
+    SSLCertificateFile %ssl_crt%
+    SSLCertificateKeyFile %ssl_key%
+    %ssl_ca_str%SSLCertificateChainFile %ssl_ca%
+
+    <IfModule mod_ruid2.c>
+        RMode config
+        RUidGid %user% %group%
+        RGroups www-data
+    </IfModule>
+    <IfModule itk.c>
+        AssignUserID %user% %group%
+    </IfModule>
+
+    Include %home%/%user%/conf/web/s%web_system%.%domain%.conf*
+
+</VirtualHost>
+

--- a/install/debian/7/templates/web/apache2/magento.stpl
+++ b/install/debian/7/templates/web/apache2/magento.stpl
@@ -16,6 +16,7 @@
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/etc/pki:/etc/ssl:/usr/local:/usr/ssl:/opt/local:/usr/local:/usr/share/ssl
+        php_admin_value always_populate_raw_post_data -1
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sys_temp_dir %home%/%user%/tmp

--- a/install/debian/7/templates/web/apache2/magento.tpl
+++ b/install/debian/7/templates/web/apache2/magento.tpl
@@ -1,0 +1,38 @@
+<VirtualHost %ip%:%web_port%>
+
+    ServerName %domain_idn%
+    %alias_string%
+    ServerAdmin %email%
+    DocumentRoot %docroot%
+    ScriptAlias /cgi-bin/ %home%/%user%/web/%domain%/cgi-bin/
+    Alias /vstats/ %home%/%user%/web/%domain%/stats/
+    Alias /error/ %home%/%user%/web/%domain%/document_errors/
+    #SuexecUserGroup %user% %group%
+    CustomLog /var/log/%web_system%/domains/%domain%.bytes bytes
+    CustomLog /var/log/%web_system%/domains/%domain%.log combined
+    ErrorLog /var/log/%web_system%/domains/%domain%.error.log
+    <Directory %docroot%>
+        AllowOverride All
+        Options +Includes -Indexes +ExecCGI
+        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/etc/pki:/etc/ssl:/usr/local:/usr/ssl:/opt/local:/usr/local:/usr/share/ssl
+        php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
+    </Directory>
+    <Directory %home%/%user%/web/%domain%/stats>
+        AllowOverride All
+    </Directory>
+
+    <IfModule mod_ruid2.c>
+        RMode config
+        RUidGid %user% %group%
+        RGroups www-data
+    </IfModule>
+    <IfModule itk.c>
+        AssignUserID %user% %group%
+    </IfModule>
+
+    Include %home%/%user%/conf/web/%web_system%.%domain%.conf*
+
+</VirtualHost>
+

--- a/install/debian/7/templates/web/apache2/magento.tpl
+++ b/install/debian/7/templates/web/apache2/magento.tpl
@@ -15,6 +15,7 @@
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/etc/pki:/etc/ssl:/usr/local:/usr/ssl:/opt/local:/usr/local:/usr/share/ssl
+        php_admin_value always_populate_raw_post_data -1
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sys_temp_dir %home%/%user%/tmp

--- a/install/debian/7/templates/web/apache2/phpcgi.stpl
+++ b/install/debian/7/templates/web/apache2/phpcgi.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/debian/7/templates/web/apache2/phpcgi.tpl
+++ b/install/debian/7/templates/web/apache2/phpcgi.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/debian/7/templates/web/apache2/phpfcgid.stpl
+++ b/install/debian/7/templates/web/apache2/phpfcgid.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/debian/7/templates/web/apache2/phpfcgid.tpl
+++ b/install/debian/7/templates/web/apache2/phpfcgid.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/debian/8/templates/web/apache2/basedir.stpl
+++ b/install/debian/8/templates/web/apache2/basedir.stpl
@@ -19,6 +19,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/debian/8/templates/web/apache2/basedir.tpl
+++ b/install/debian/8/templates/web/apache2/basedir.tpl
@@ -18,6 +18,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/debian/8/templates/web/apache2/default.stpl
+++ b/install/debian/8/templates/web/apache2/default.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/debian/8/templates/web/apache2/default.tpl
+++ b/install/debian/8/templates/web/apache2/default.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/debian/8/templates/web/apache2/hosting.stpl
+++ b/install/debian/8/templates/web/apache2/hosting.stpl
@@ -25,6 +25,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/debian/8/templates/web/apache2/hosting.tpl
+++ b/install/debian/8/templates/web/apache2/hosting.tpl
@@ -24,6 +24,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/debian/8/templates/web/apache2/magento.stpl
+++ b/install/debian/8/templates/web/apache2/magento.stpl
@@ -16,6 +16,7 @@
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/etc/pki:/etc/ssl:/usr/local:/usr/ssl:/opt/local:/usr/local:/usr/share/ssl
+        php_admin_value always_populate_raw_post_data -1
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sys_temp_dir %home%/%user%/tmp

--- a/install/debian/8/templates/web/apache2/magento.stpl
+++ b/install/debian/8/templates/web/apache2/magento.stpl
@@ -7,34 +7,38 @@
     ScriptAlias /cgi-bin/ %home%/%user%/web/%domain%/cgi-bin/
     Alias /vstats/ %home%/%user%/web/%domain%/stats/
     Alias /error/ %home%/%user%/web/%domain%/document_errors/
-    SuexecUserGroup %user% %group%
-    CustomLog /var/log/httpd/domains/%domain%.bytes bytes
-    CustomLog /var/log/httpd/domains/%domain%.log combined
-    ErrorLog /var/log/httpd/domains/%domain%.error.log
+    #SuexecUserGroup %user% %group%
+    CustomLog /var/log/%web_system%/domains/%domain%.bytes bytes
+    CustomLog /var/log/%web_system%/domains/%domain%.log combined
+    ErrorLog /var/log/%web_system%/domains/%domain%.error.log
     <Directory %sdocroot%>
-        SSLRequireSSL
         AllowOverride All
+        SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/etc/pki:/etc/ssl:/usr/local:/usr/ssl:/opt/local:/usr/local:/usr/share/ssl
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sys_temp_dir %home%/%user%/tmp
-        <Files *.php>
-          SetHandler fcgid-script
-        </Files>
-        FCGIWrapper %home%/%user%/web/%domain%/cgi-bin/fcgi-starter .php
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All
     </Directory>
-    php_admin_value open_basedir none
     SSLEngine on
     SSLVerifyClient none
     SSLCertificateFile %ssl_crt%
     SSLCertificateKeyFile %ssl_key%
     %ssl_ca_str%SSLCertificateChainFile %ssl_ca%
 
-    Include %home%/%user%/conf/web/shttpd.%domain%.conf*
+    <IfModule mod_ruid2.c>
+        RMode config
+        RUidGid %user% %group%
+        RGroups www-data
+    </IfModule>
+    <IfModule itk.c>
+        AssignUserID %user% %group%
+    </IfModule>
+
+    IncludeOptional %home%/%user%/conf/web/s%web_system%.%domain%.conf*
 
 </VirtualHost>
 

--- a/install/debian/8/templates/web/apache2/magento.tpl
+++ b/install/debian/8/templates/web/apache2/magento.tpl
@@ -15,6 +15,7 @@
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/etc/pki:/etc/ssl:/usr/local:/usr/ssl:/opt/local:/usr/local:/usr/share/ssl
+        php_admin_value always_populate_raw_post_data -1
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sys_temp_dir %home%/%user%/tmp

--- a/install/debian/8/templates/web/apache2/magento.tpl
+++ b/install/debian/8/templates/web/apache2/magento.tpl
@@ -1,9 +1,9 @@
-<VirtualHost %ip%:%web_ssl_port%>
+<VirtualHost %ip%:%web_port%>
 
     ServerName %domain_idn%
     %alias_string%
     ServerAdmin %email%
-    DocumentRoot %sdocroot%
+    DocumentRoot %docroot%
     ScriptAlias /cgi-bin/ %home%/%user%/web/%domain%/cgi-bin/
     Alias /vstats/ %home%/%user%/web/%domain%/stats/
     Alias /error/ %home%/%user%/web/%domain%/document_errors/
@@ -11,11 +11,10 @@
     CustomLog /var/log/%web_system%/domains/%domain%.bytes bytes
     CustomLog /var/log/%web_system%/domains/%domain%.log combined
     ErrorLog /var/log/%web_system%/domains/%domain%.error.log
-    <Directory %sdocroot%>
+    <Directory %docroot%>
         AllowOverride All
-        SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/etc/pki:/etc/ssl:/usr/local:/usr/ssl:/opt/local:/usr/local:/usr/share/ssl
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sys_temp_dir %home%/%user%/tmp
@@ -23,22 +22,17 @@
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All
     </Directory>
-    SSLEngine on
-    SSLVerifyClient none
-    SSLCertificateFile %ssl_crt%
-    SSLCertificateKeyFile %ssl_key%
-    %ssl_ca_str%SSLCertificateChainFile %ssl_ca%
 
     <IfModule mod_ruid2.c>
         RMode config
         RUidGid %user% %group%
-        RGroups apache
+        RGroups www-data
     </IfModule>
     <IfModule itk.c>
         AssignUserID %user% %group%
     </IfModule>
 
-    Include %home%/%user%/conf/web/s%web_system%.%domain%.conf*
+    IncludeOptional %home%/%user%/conf/web/%web_system%.%domain%.conf*
 
 </VirtualHost>
 

--- a/install/debian/8/templates/web/apache2/phpcgi.stpl
+++ b/install/debian/8/templates/web/apache2/phpcgi.stpl
@@ -18,6 +18,8 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
+        
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/debian/8/templates/web/apache2/phpcgi.tpl
+++ b/install/debian/8/templates/web/apache2/phpcgi.tpl
@@ -18,6 +18,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
             SetHandler phpcgi-script
         </Files>

--- a/install/debian/8/templates/web/apache2/phpfcgid.stpl
+++ b/install/debian/8/templates/web/apache2/phpfcgid.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/debian/8/templates/web/apache2/phpfcgid.tpl
+++ b/install/debian/8/templates/web/apache2/phpfcgid.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/rhel/5/templates/web/httpd/basedir.stpl
+++ b/install/rhel/5/templates/web/httpd/basedir.stpl
@@ -19,6 +19,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/5/templates/web/httpd/basedir.tpl
+++ b/install/rhel/5/templates/web/httpd/basedir.tpl
@@ -18,6 +18,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/5/templates/web/httpd/default.stpl
+++ b/install/rhel/5/templates/web/httpd/default.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/5/templates/web/httpd/default.tpl
+++ b/install/rhel/5/templates/web/httpd/default.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/5/templates/web/httpd/hosting.stpl
+++ b/install/rhel/5/templates/web/httpd/hosting.stpl
@@ -25,6 +25,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/5/templates/web/httpd/hosting.tpl
+++ b/install/rhel/5/templates/web/httpd/hosting.tpl
@@ -24,6 +24,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/5/templates/web/httpd/magento.stpl
+++ b/install/rhel/5/templates/web/httpd/magento.stpl
@@ -16,6 +16,7 @@
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/etc/pki:/etc/ssl:/usr/local:/usr/ssl:/opt/local:/usr/local:/usr/share/ssl
+        php_admin_value always_populate_raw_post_data -1
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sys_temp_dir %home%/%user%/tmp

--- a/install/rhel/5/templates/web/httpd/magento.stpl
+++ b/install/rhel/5/templates/web/httpd/magento.stpl
@@ -7,34 +7,38 @@
     ScriptAlias /cgi-bin/ %home%/%user%/web/%domain%/cgi-bin/
     Alias /vstats/ %home%/%user%/web/%domain%/stats/
     Alias /error/ %home%/%user%/web/%domain%/document_errors/
-    SuexecUserGroup %user% %group%
-    CustomLog /var/log/httpd/domains/%domain%.bytes bytes
-    CustomLog /var/log/httpd/domains/%domain%.log combined
-    ErrorLog /var/log/httpd/domains/%domain%.error.log
+    #SuexecUserGroup %user% %group%
+    CustomLog /var/log/%web_system%/domains/%domain%.bytes bytes
+    CustomLog /var/log/%web_system%/domains/%domain%.log combined
+    ErrorLog /var/log/%web_system%/domains/%domain%.error.log
     <Directory %sdocroot%>
-        SSLRequireSSL
         AllowOverride All
+        SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/etc/pki:/etc/ssl:/usr/local:/usr/ssl:/opt/local:/usr/local:/usr/share/ssl
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sys_temp_dir %home%/%user%/tmp
-        <Files *.php>
-          SetHandler fcgid-script
-        </Files>
-        FCGIWrapper %home%/%user%/web/%domain%/cgi-bin/fcgi-starter .php
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All
     </Directory>
-    php_admin_value open_basedir none
     SSLEngine on
     SSLVerifyClient none
     SSLCertificateFile %ssl_crt%
     SSLCertificateKeyFile %ssl_key%
     %ssl_ca_str%SSLCertificateChainFile %ssl_ca%
 
-    Include %home%/%user%/conf/web/shttpd.%domain%.conf*
+    <IfModule mod_ruid2.c>
+        RMode config
+        RUidGid %user% %group%
+        RGroups apache
+    </IfModule>
+    <IfModule itk.c>
+        AssignUserID %user% %group%
+    </IfModule>
+
+    Include %home%/%user%/conf/web/s%web_system%.%domain%.conf*
 
 </VirtualHost>
 

--- a/install/rhel/5/templates/web/httpd/magento.tpl
+++ b/install/rhel/5/templates/web/httpd/magento.tpl
@@ -1,9 +1,9 @@
-<VirtualHost %ip%:%web_ssl_port%>
+<VirtualHost %ip%:%web_port%>
 
     ServerName %domain_idn%
     %alias_string%
     ServerAdmin %email%
-    DocumentRoot %sdocroot%
+    DocumentRoot %docroot%
     ScriptAlias /cgi-bin/ %home%/%user%/web/%domain%/cgi-bin/
     Alias /vstats/ %home%/%user%/web/%domain%/stats/
     Alias /error/ %home%/%user%/web/%domain%/document_errors/
@@ -11,11 +11,10 @@
     CustomLog /var/log/%web_system%/domains/%domain%.bytes bytes
     CustomLog /var/log/%web_system%/domains/%domain%.log combined
     ErrorLog /var/log/%web_system%/domains/%domain%.error.log
-    <Directory %sdocroot%>
+    <Directory %docroot%>
         AllowOverride All
-        SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/etc/pki:/etc/ssl:/usr/local:/usr/ssl:/opt/local:/usr/local:/usr/share/ssl
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sys_temp_dir %home%/%user%/tmp
@@ -23,11 +22,6 @@
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All
     </Directory>
-    SSLEngine on
-    SSLVerifyClient none
-    SSLCertificateFile %ssl_crt%
-    SSLCertificateKeyFile %ssl_key%
-    %ssl_ca_str%SSLCertificateChainFile %ssl_ca%
 
     <IfModule mod_ruid2.c>
         RMode config
@@ -38,7 +32,7 @@
         AssignUserID %user% %group%
     </IfModule>
 
-    Include %home%/%user%/conf/web/s%web_system%.%domain%.conf*
+    Include %home%/%user%/conf/web/%web_system%.%domain%.conf*
 
 </VirtualHost>
 

--- a/install/rhel/5/templates/web/httpd/magento.tpl
+++ b/install/rhel/5/templates/web/httpd/magento.tpl
@@ -15,6 +15,7 @@
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/etc/pki:/etc/ssl:/usr/local:/usr/ssl:/opt/local:/usr/local:/usr/share/ssl
+        php_admin_value always_populate_raw_post_data -1
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sys_temp_dir %home%/%user%/tmp

--- a/install/rhel/5/templates/web/httpd/phpcgi.stpl
+++ b/install/rhel/5/templates/web/httpd/phpcgi.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/rhel/5/templates/web/httpd/phpcgi.tpl
+++ b/install/rhel/5/templates/web/httpd/phpcgi.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/rhel/5/templates/web/httpd/phpfcgid.stpl
+++ b/install/rhel/5/templates/web/httpd/phpfcgid.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/rhel/5/templates/web/httpd/phpfcgid.tpl
+++ b/install/rhel/5/templates/web/httpd/phpfcgid.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/rhel/6/templates/web/httpd/basedir.stpl
+++ b/install/rhel/6/templates/web/httpd/basedir.stpl
@@ -19,6 +19,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/6/templates/web/httpd/basedir.tpl
+++ b/install/rhel/6/templates/web/httpd/basedir.tpl
@@ -18,6 +18,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/6/templates/web/httpd/default.tpl
+++ b/install/rhel/6/templates/web/httpd/default.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/6/templates/web/httpd/hosting.stpl
+++ b/install/rhel/6/templates/web/httpd/hosting.stpl
@@ -23,6 +23,7 @@
         php_admin_flag safe_mode off
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
+        php_admin_value always_populate_raw_post_data -1
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sys_temp_dir %home%/%user%/tmp

--- a/install/rhel/6/templates/web/httpd/hosting.stpl
+++ b/install/rhel/6/templates/web/httpd/hosting.stpl
@@ -25,6 +25,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/6/templates/web/httpd/hosting.tpl
+++ b/install/rhel/6/templates/web/httpd/hosting.tpl
@@ -22,6 +22,7 @@
         php_admin_flag safe_mode off
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
+        php_admin_value always_populate_raw_post_data -1
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sys_temp_dir %home%/%user%/tmp

--- a/install/rhel/6/templates/web/httpd/hosting.tpl
+++ b/install/rhel/6/templates/web/httpd/hosting.tpl
@@ -24,6 +24,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/6/templates/web/httpd/magento.stpl
+++ b/install/rhel/6/templates/web/httpd/magento.stpl
@@ -7,34 +7,38 @@
     ScriptAlias /cgi-bin/ %home%/%user%/web/%domain%/cgi-bin/
     Alias /vstats/ %home%/%user%/web/%domain%/stats/
     Alias /error/ %home%/%user%/web/%domain%/document_errors/
-    SuexecUserGroup %user% %group%
-    CustomLog /var/log/httpd/domains/%domain%.bytes bytes
-    CustomLog /var/log/httpd/domains/%domain%.log combined
-    ErrorLog /var/log/httpd/domains/%domain%.error.log
+    #SuexecUserGroup %user% %group%
+    CustomLog /var/log/%web_system%/domains/%domain%.bytes bytes
+    CustomLog /var/log/%web_system%/domains/%domain%.log combined
+    ErrorLog /var/log/%web_system%/domains/%domain%.error.log
     <Directory %sdocroot%>
-        SSLRequireSSL
         AllowOverride All
+        SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/etc/pki:/etc/ssl:/usr/local:/usr/ssl:/opt/local:/usr/local:/usr/share/ssl
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sys_temp_dir %home%/%user%/tmp
-        <Files *.php>
-          SetHandler fcgid-script
-        </Files>
-        FCGIWrapper %home%/%user%/web/%domain%/cgi-bin/fcgi-starter .php
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All
     </Directory>
-    php_admin_value open_basedir none
     SSLEngine on
     SSLVerifyClient none
     SSLCertificateFile %ssl_crt%
     SSLCertificateKeyFile %ssl_key%
     %ssl_ca_str%SSLCertificateChainFile %ssl_ca%
 
-    Include %home%/%user%/conf/web/shttpd.%domain%.conf*
+    <IfModule mod_ruid2.c>
+        RMode config
+        RUidGid %user% %group%
+        RGroups apache
+    </IfModule>
+    <IfModule itk.c>
+        AssignUserID %user% %group%
+    </IfModule>
+
+    Include %home%/%user%/conf/web/s%web_system%.%domain%.conf*
 
 </VirtualHost>
 

--- a/install/rhel/6/templates/web/httpd/magento.tpl
+++ b/install/rhel/6/templates/web/httpd/magento.tpl
@@ -1,9 +1,9 @@
-<VirtualHost %ip%:%web_ssl_port%>
+<VirtualHost %ip%:%web_port%>
 
     ServerName %domain_idn%
     %alias_string%
     ServerAdmin %email%
-    DocumentRoot %sdocroot%
+    DocumentRoot %docroot%
     ScriptAlias /cgi-bin/ %home%/%user%/web/%domain%/cgi-bin/
     Alias /vstats/ %home%/%user%/web/%domain%/stats/
     Alias /error/ %home%/%user%/web/%domain%/document_errors/
@@ -11,11 +11,10 @@
     CustomLog /var/log/%web_system%/domains/%domain%.bytes bytes
     CustomLog /var/log/%web_system%/domains/%domain%.log combined
     ErrorLog /var/log/%web_system%/domains/%domain%.error.log
-    <Directory %sdocroot%>
+    <Directory %docroot%>
         AllowOverride All
-        SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/etc/pki:/etc/ssl:/usr/local:/usr/ssl:/opt/local:/usr/local:/usr/share/ssl
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sys_temp_dir %home%/%user%/tmp
@@ -23,11 +22,6 @@
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All
     </Directory>
-    SSLEngine on
-    SSLVerifyClient none
-    SSLCertificateFile %ssl_crt%
-    SSLCertificateKeyFile %ssl_key%
-    %ssl_ca_str%SSLCertificateChainFile %ssl_ca%
 
     <IfModule mod_ruid2.c>
         RMode config
@@ -38,7 +32,7 @@
         AssignUserID %user% %group%
     </IfModule>
 
-    Include %home%/%user%/conf/web/s%web_system%.%domain%.conf*
+    Include %home%/%user%/conf/web/%web_system%.%domain%.conf*
 
 </VirtualHost>
 

--- a/install/rhel/6/templates/web/httpd/phpcgi.stpl
+++ b/install/rhel/6/templates/web/httpd/phpcgi.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/rhel/6/templates/web/httpd/phpcgi.tpl
+++ b/install/rhel/6/templates/web/httpd/phpcgi.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/rhel/6/templates/web/httpd/phpfcgid.tpl
+++ b/install/rhel/6/templates/web/httpd/phpfcgid.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/rhel/7/templates/web/httpd/basedir.stpl
+++ b/install/rhel/7/templates/web/httpd/basedir.stpl
@@ -19,6 +19,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/7/templates/web/httpd/basedir.tpl
+++ b/install/rhel/7/templates/web/httpd/basedir.tpl
@@ -18,6 +18,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/7/templates/web/httpd/default.stpl
+++ b/install/rhel/7/templates/web/httpd/default.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/7/templates/web/httpd/default.tpl
+++ b/install/rhel/7/templates/web/httpd/default.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/7/templates/web/httpd/hosting.stpl
+++ b/install/rhel/7/templates/web/httpd/hosting.stpl
@@ -25,6 +25,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/7/templates/web/httpd/hosting.tpl
+++ b/install/rhel/7/templates/web/httpd/hosting.tpl
@@ -24,6 +24,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/rhel/7/templates/web/httpd/magento.stpl
+++ b/install/rhel/7/templates/web/httpd/magento.stpl
@@ -16,6 +16,7 @@
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/etc/pki:/etc/ssl:/usr/local:/usr/ssl:/opt/local:/usr/local:/usr/share/ssl
+        php_admin_value always_populate_raw_post_data -1
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sys_temp_dir %home%/%user%/tmp

--- a/install/rhel/7/templates/web/httpd/magento.stpl
+++ b/install/rhel/7/templates/web/httpd/magento.stpl
@@ -7,34 +7,38 @@
     ScriptAlias /cgi-bin/ %home%/%user%/web/%domain%/cgi-bin/
     Alias /vstats/ %home%/%user%/web/%domain%/stats/
     Alias /error/ %home%/%user%/web/%domain%/document_errors/
-    SuexecUserGroup %user% %group%
-    CustomLog /var/log/httpd/domains/%domain%.bytes bytes
-    CustomLog /var/log/httpd/domains/%domain%.log combined
-    ErrorLog /var/log/httpd/domains/%domain%.error.log
+    #SuexecUserGroup %user% %group%
+    CustomLog /var/log/%web_system%/domains/%domain%.bytes bytes
+    CustomLog /var/log/%web_system%/domains/%domain%.log combined
+    ErrorLog /var/log/%web_system%/domains/%domain%.error.log
     <Directory %sdocroot%>
-        SSLRequireSSL
         AllowOverride All
+        SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/etc/pki:/etc/ssl:/usr/local:/usr/ssl:/opt/local:/usr/local:/usr/share/ssl
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sys_temp_dir %home%/%user%/tmp
-        <Files *.php>
-          SetHandler fcgid-script
-        </Files>
-        FCGIWrapper %home%/%user%/web/%domain%/cgi-bin/fcgi-starter .php
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All
     </Directory>
-    php_admin_value open_basedir none
     SSLEngine on
     SSLVerifyClient none
     SSLCertificateFile %ssl_crt%
     SSLCertificateKeyFile %ssl_key%
     %ssl_ca_str%SSLCertificateChainFile %ssl_ca%
 
-    Include %home%/%user%/conf/web/shttpd.%domain%.conf*
+    <IfModule mod_ruid2.c>
+        RMode config
+        RUidGid %user% %group%
+        RGroups apache
+    </IfModule>
+    <IfModule itk.c>
+        AssignUserID %user% %group%
+    </IfModule>
+
+    IncludeOptional %home%/%user%/conf/web/s%web_system%.%domain%.conf*
 
 </VirtualHost>
 

--- a/install/rhel/7/templates/web/httpd/magento.tpl
+++ b/install/rhel/7/templates/web/httpd/magento.tpl
@@ -1,9 +1,9 @@
-<VirtualHost %ip%:%web_ssl_port%>
+<VirtualHost %ip%:%web_port%>
 
     ServerName %domain_idn%
     %alias_string%
     ServerAdmin %email%
-    DocumentRoot %sdocroot%
+    DocumentRoot %docroot%
     ScriptAlias /cgi-bin/ %home%/%user%/web/%domain%/cgi-bin/
     Alias /vstats/ %home%/%user%/web/%domain%/stats/
     Alias /error/ %home%/%user%/web/%domain%/document_errors/
@@ -11,11 +11,10 @@
     CustomLog /var/log/%web_system%/domains/%domain%.bytes bytes
     CustomLog /var/log/%web_system%/domains/%domain%.log combined
     ErrorLog /var/log/%web_system%/domains/%domain%.error.log
-    <Directory %sdocroot%>
+    <Directory %docroot%>
         AllowOverride All
-        SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/etc/pki:/etc/ssl:/usr/local:/usr/ssl:/opt/local:/usr/local:/usr/share/ssl
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sys_temp_dir %home%/%user%/tmp
@@ -23,11 +22,6 @@
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All
     </Directory>
-    SSLEngine on
-    SSLVerifyClient none
-    SSLCertificateFile %ssl_crt%
-    SSLCertificateKeyFile %ssl_key%
-    %ssl_ca_str%SSLCertificateChainFile %ssl_ca%
 
     <IfModule mod_ruid2.c>
         RMode config
@@ -38,7 +32,7 @@
         AssignUserID %user% %group%
     </IfModule>
 
-    Include %home%/%user%/conf/web/s%web_system%.%domain%.conf*
+    IncludeOptional %home%/%user%/conf/web/%web_system%.%domain%.conf*
 
 </VirtualHost>
 

--- a/install/rhel/7/templates/web/httpd/magento.tpl
+++ b/install/rhel/7/templates/web/httpd/magento.tpl
@@ -15,6 +15,7 @@
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/etc/pki:/etc/ssl:/usr/local:/usr/ssl:/opt/local:/usr/local:/usr/share/ssl
+        php_admin_value always_populate_raw_post_data -1
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sys_temp_dir %home%/%user%/tmp

--- a/install/rhel/7/templates/web/httpd/phpcgi.stpl
+++ b/install/rhel/7/templates/web/httpd/phpcgi.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/rhel/7/templates/web/httpd/phpcgi.tpl
+++ b/install/rhel/7/templates/web/httpd/phpcgi.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/rhel/7/templates/web/httpd/phpfcgid.stpl
+++ b/install/rhel/7/templates/web/httpd/phpfcgid.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/rhel/7/templates/web/httpd/phpfcgid.tpl
+++ b/install/rhel/7/templates/web/httpd/phpfcgid.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/ubuntu/12.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/12.04/templates/web/apache2/basedir.stpl
@@ -19,6 +19,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/12.04/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/12.04/templates/web/apache2/basedir.tpl
@@ -18,6 +18,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/12.04/templates/web/apache2/default.stpl
+++ b/install/ubuntu/12.04/templates/web/apache2/default.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/12.04/templates/web/apache2/default.tpl
+++ b/install/ubuntu/12.04/templates/web/apache2/default.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/12.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/12.04/templates/web/apache2/hosting.stpl
@@ -25,6 +25,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/12.04/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/12.04/templates/web/apache2/hosting.tpl
@@ -24,6 +24,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/12.04/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/12.04/templates/web/apache2/phpcgi.stpl
@@ -19,6 +19,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
             SetHandler phpcgi-script
         </Files>

--- a/install/ubuntu/12.04/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/12.04/templates/web/apache2/phpcgi.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/ubuntu/12.04/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/12.04/templates/web/apache2/phpfcgid.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/ubuntu/12.04/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/12.04/templates/web/apache2/phpfcgid.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/ubuntu/12.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/12.10/templates/web/apache2/basedir.stpl
@@ -19,6 +19,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/12.10/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/12.10/templates/web/apache2/basedir.tpl
@@ -18,6 +18,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/12.10/templates/web/apache2/default.stpl
+++ b/install/ubuntu/12.10/templates/web/apache2/default.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/12.10/templates/web/apache2/default.tpl
+++ b/install/ubuntu/12.10/templates/web/apache2/default.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/12.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/12.10/templates/web/apache2/hosting.stpl
@@ -25,6 +25,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/12.10/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/12.10/templates/web/apache2/hosting.tpl
@@ -24,6 +24,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/12.10/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/12.10/templates/web/apache2/phpcgi.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/ubuntu/12.10/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/12.10/templates/web/apache2/phpcgi.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/ubuntu/12.10/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/12.10/templates/web/apache2/phpfcgid.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/ubuntu/12.10/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/12.10/templates/web/apache2/phpfcgid.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/ubuntu/13.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/13.04/templates/web/apache2/basedir.stpl
@@ -19,6 +19,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/13.04/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/13.04/templates/web/apache2/basedir.tpl
@@ -18,6 +18,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/13.04/templates/web/apache2/default.stpl
+++ b/install/ubuntu/13.04/templates/web/apache2/default.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/13.04/templates/web/apache2/default.tpl
+++ b/install/ubuntu/13.04/templates/web/apache2/default.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/13.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/13.04/templates/web/apache2/hosting.stpl
@@ -25,6 +25,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/13.04/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/13.04/templates/web/apache2/hosting.tpl
@@ -24,6 +24,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/13.04/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/13.04/templates/web/apache2/phpcgi.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/ubuntu/13.04/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/13.04/templates/web/apache2/phpcgi.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/ubuntu/13.04/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/13.04/templates/web/apache2/phpfcgid.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/ubuntu/13.04/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/13.04/templates/web/apache2/phpfcgid.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/ubuntu/13.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/13.10/templates/web/apache2/basedir.stpl
@@ -19,6 +19,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/13.10/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/13.10/templates/web/apache2/basedir.tpl
@@ -18,6 +18,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/13.10/templates/web/apache2/default.stpl
+++ b/install/ubuntu/13.10/templates/web/apache2/default.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/13.10/templates/web/apache2/default.tpl
+++ b/install/ubuntu/13.10/templates/web/apache2/default.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/13.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/13.10/templates/web/apache2/hosting.stpl
@@ -25,6 +25,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/13.10/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/13.10/templates/web/apache2/hosting.tpl
@@ -24,6 +24,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/13.10/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/13.10/templates/web/apache2/phpcgi.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/ubuntu/13.10/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/13.10/templates/web/apache2/phpcgi.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/ubuntu/13.10/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/13.10/templates/web/apache2/phpfcgid.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/ubuntu/13.10/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/13.10/templates/web/apache2/phpfcgid.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/ubuntu/14.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/14.04/templates/web/apache2/basedir.stpl
@@ -19,6 +19,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/14.04/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/14.04/templates/web/apache2/basedir.tpl
@@ -18,6 +18,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/14.04/templates/web/apache2/default.stpl
+++ b/install/ubuntu/14.04/templates/web/apache2/default.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/14.04/templates/web/apache2/default.tpl
+++ b/install/ubuntu/14.04/templates/web/apache2/default.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/14.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/14.04/templates/web/apache2/hosting.stpl
@@ -25,6 +25,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/14.04/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/14.04/templates/web/apache2/hosting.tpl
@@ -24,6 +24,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/14.04/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/14.04/templates/web/apache2/phpcgi.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/ubuntu/14.04/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/14.04/templates/web/apache2/phpcgi.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/ubuntu/14.04/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/14.04/templates/web/apache2/phpfcgid.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/ubuntu/14.04/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/14.04/templates/web/apache2/phpfcgid.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/ubuntu/14.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/14.10/templates/web/apache2/basedir.stpl
@@ -19,6 +19,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/14.10/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/14.10/templates/web/apache2/basedir.tpl
@@ -18,6 +18,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/14.10/templates/web/apache2/default.stpl
+++ b/install/ubuntu/14.10/templates/web/apache2/default.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/14.10/templates/web/apache2/default.tpl
+++ b/install/ubuntu/14.10/templates/web/apache2/default.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/14.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/14.10/templates/web/apache2/hosting.stpl
@@ -25,6 +25,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/14.10/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/14.10/templates/web/apache2/hosting.tpl
@@ -24,6 +24,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/14.10/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/14.10/templates/web/apache2/phpcgi.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/ubuntu/14.10/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/14.10/templates/web/apache2/phpcgi.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/ubuntu/14.10/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/14.10/templates/web/apache2/phpfcgid.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/ubuntu/14.10/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/14.10/templates/web/apache2/phpfcgid.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/ubuntu/15.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/15.04/templates/web/apache2/basedir.stpl
@@ -19,6 +19,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/15.04/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/15.04/templates/web/apache2/basedir.tpl
@@ -18,6 +18,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/15.04/templates/web/apache2/default.stpl
+++ b/install/ubuntu/15.04/templates/web/apache2/default.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/15.04/templates/web/apache2/default.tpl
+++ b/install/ubuntu/15.04/templates/web/apache2/default.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/15.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/15.04/templates/web/apache2/hosting.stpl
@@ -25,6 +25,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/15.04/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/15.04/templates/web/apache2/hosting.tpl
@@ -24,6 +24,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/15.04/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/15.04/templates/web/apache2/phpcgi.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/ubuntu/15.04/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/15.04/templates/web/apache2/phpcgi.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/ubuntu/15.04/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/15.04/templates/web/apache2/phpfcgid.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/ubuntu/15.04/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/15.04/templates/web/apache2/phpfcgid.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/ubuntu/15.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/15.10/templates/web/apache2/basedir.stpl
@@ -19,6 +19,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/15.10/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/15.10/templates/web/apache2/basedir.tpl
@@ -18,6 +18,7 @@
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/15.10/templates/web/apache2/default.stpl
+++ b/install/ubuntu/15.10/templates/web/apache2/default.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/15.10/templates/web/apache2/default.tpl
+++ b/install/ubuntu/15.10/templates/web/apache2/default.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/15.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/15.10/templates/web/apache2/hosting.stpl
@@ -25,6 +25,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/15.10/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/15.10/templates/web/apache2/hosting.tpl
@@ -24,6 +24,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>
         AllowOverride All

--- a/install/ubuntu/15.10/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/15.10/templates/web/apache2/phpcgi.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/ubuntu/15.10/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/15.10/templates/web/apache2/phpcgi.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>
             SetHandler phpcgi-script

--- a/install/ubuntu/15.10/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/15.10/templates/web/apache2/phpfcgid.stpl
@@ -18,6 +18,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/ubuntu/15.10/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/15.10/templates/web/apache2/phpfcgid.tpl
@@ -17,6 +17,7 @@
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script
         </Files>

--- a/install/vst-install-rhel.sh
+++ b/install/vst-install-rhel.sh
@@ -23,7 +23,7 @@ if [ "$release" -eq 7 ]; then
     php-bcmath php-gd php-imap php-mbstring php-mcrypt php-mysql php-pdo
     php-soap php-tidy php-xml php-xmlrpc php-fpm php-pgsql awstats webalizer
     vsftpd proftpd bind bind-utils bind-libs exim dovecot clamav-server
-    clamav-update spamassassin roundcubemail mariadb mariadb-server phpMyAdmin
+    clamav-update spamassassin roundcubemail mysql-community-server phpMyAdmin
     postgresql postgresql-server postgresql-contrib phpPgAdmin e2fsprogs
     openssh-clients ImageMagick curl mc screen ftp zip unzip flex sqlite pcre
     sudo bc jwhois mailx lsof tar telnet rrdtool net-tools ntp GeoIP freetype
@@ -323,7 +323,7 @@ fi
 # DB stack
 if [ "$mysql" = 'yes' ]; then
     if [ $release = 7 ]; then
-        echo '   - MariaDB Database Server'
+        echo '   - MySQL Database Server'
     else
         echo '   - MySQL Database Server'
     fi
@@ -517,7 +517,6 @@ cp -r /etc/dovecot/* $vst_backups/dovecot > /dev/null 2>&1
 # Backing up MySQL/MariaDB configuration and data
 service mysql stop > /dev/null 2>&1
 service mysqld stop > /dev/null 2>&1
-service mariadb stop > /dev/null 2>&1
 mv /var/lib/mysql $vst_backups/mysql/mysql_datadir >/dev/null 2>&1
 cp /etc/my.cnf $vst_backups/mysql > /dev/null 2>&1
 cp /etc/my.cnf.d $vst_backups/mysql > /dev/null 2>&1
@@ -606,6 +605,11 @@ fi
 #----------------------------------------------------------#
 
 # Installing rpm packages
+# Adicionando RPM do MySQL community
+if [ $release -ne 7 ]; then
+    rpm -Uvh http://dev.mysql.com/get/mysql-community-release-el7-5.noarch.rpm
+fi
+
 if [ -z "$disable_remi" ]; then 
     yum -y --disablerepo=* --enablerepo="base,updates,nginx,epel,vesta,remi*"\
         install $software
@@ -960,7 +964,7 @@ if [ "$mysql" = 'yes' ]; then
     if [ $release -ne 7 ]; then
         service='mysqld'
     else
-        service='mariadb'
+        service='mysqld'
     fi
 
     wget $vestacp/$service/$mycnf -O /etc/my.cnf


### PR DESCRIPTION
Invoking the method sys_get_temp_dir I got the return / tmp and it gave error because the open_basedir restriction, found this solution and decided to share with the community.
