### PR TITLE
Fix httpauth permission server error and secure template

### DIFF
--- a/bin/v-add-web-domain-httpauth
+++ b/bin/v-add-web-domain-httpauth
@@ -24,6 +24,8 @@ source $VESTA/conf/vesta.conf
 # Defining htpasswd file
 htaccess="$HOMEDIR/$user/conf/web/$WEB_SYSTEM.$domain.conf_htaccess"
 htpasswd="$HOMEDIR/$user/conf/web/$WEB_SYSTEM.$domain.htpasswd"
+shtaccess="$HOMEDIR/$user/conf/web/s$WEB_SYSTEM.$domain.conf_htaccess"
+shtpasswd="$HOMEDIR/$user/conf/web/s$WEB_SYSTEM.$domain.htpasswd"
 docroot="$HOMEDIR/$user/web/$domain/public_html"
 
 
@@ -75,14 +77,14 @@ chgrp $user $htpasswd $htaccess
 sed -i "/^$auth_user:/d" $htpasswd
 echo "$auth_user:$auth_hash" >> $htpasswd
 
-ln -s "$HOMEDIR/$user/conf/web/$WEB_SYSTEM.$domain.conf_htaccess" "$HOMEDIR/$user/conf/web/s$WEB_SYSTEM.$domain.conf_htaccess"
-ln -s "$HOMEDIR/$user/conf/web/$WEB_SYSTEM.$domain.htpasswd" "$HOMEDIR/$user/conf/web/s$WEB_SYSTEM.$domain.htpasswd"
+# Symbolic link for secure web templates
+ln -s $htpasswd $shtpasswd 
+ln -s $htaccess $shtaccess
 
 # Restarting web server
 if [ "$restart" != 'no' ] && [ "$restart_required" = 'yes' ]; then
     $BIN/v-restart-web
 fi
-
 
 #----------------------------------------------------------#
 #                       Vesta                              #

--- a/bin/v-add-web-domain-httpauth
+++ b/bin/v-add-web-domain-httpauth
@@ -75,8 +75,8 @@ chgrp $user $htpasswd $htaccess
 sed -i "/^$auth_user:/d" $htpasswd
 echo "$auth_user:$auth_hash" >> $htpasswd
 
-cp -p "$HOMEDIR/$user/conf/web/$WEB_SYSTEM.$domain.conf_htaccess" "$HOMEDIR/$user/conf/web/s$WEB_SYSTEM.$domain.conf_htaccess"
-cp -p "$HOMEDIR/$user/conf/web/$WEB_SYSTEM.$domain.htpasswd" "$HOMEDIR/$user/conf/web/s$WEB_SYSTEM.$domain.htpasswd"
+ln -s "$HOMEDIR/$user/conf/web/$WEB_SYSTEM.$domain.conf_htaccess" "$HOMEDIR/$user/conf/web/s$WEB_SYSTEM.$domain.conf_htaccess"
+ln -s "$HOMEDIR/$user/conf/web/$WEB_SYSTEM.$domain.htpasswd" "$HOMEDIR/$user/conf/web/s$WEB_SYSTEM.$domain.htpasswd"
 
 # Restarting web server
 if [ "$restart" != 'no' ] && [ "$restart_required" = 'yes' ]; then

--- a/bin/v-add-web-domain-httpauth
+++ b/bin/v-add-web-domain-httpauth
@@ -71,8 +71,12 @@ fi
 auth_hash=$($BIN/v-generate-password-hash htpasswd htpasswd $password)
 touch $htpasswd
 chmod 640 $htpasswd $htaccess
+chgrp $user $htpasswd $htaccess
 sed -i "/^$auth_user:/d" $htpasswd
 echo "$auth_user:$auth_hash" >> $htpasswd
+
+cp -p "$HOMEDIR/$user/conf/web/$WEB_SYSTEM.$domain.conf_htaccess" "$HOMEDIR/$user/conf/web/s$WEB_SYSTEM.$domain.conf_htaccess"
+cp -p "$HOMEDIR/$user/conf/web/$WEB_SYSTEM.$domain.htpasswd" "$HOMEDIR/$user/conf/web/s$WEB_SYSTEM.$domain.htpasswd"
 
 # Restarting web server
 if [ "$restart" != 'no' ] && [ "$restart_required" = 'yes' ]; then

--- a/bin/v-add-web-domain-httpauth
+++ b/bin/v-add-web-domain-httpauth
@@ -78,8 +78,12 @@ sed -i "/^$auth_user:/d" $htpasswd
 echo "$auth_user:$auth_hash" >> $htpasswd
 
 # Symbolic link for secure web templates
-ln -s $htpasswd $shtpasswd 
+if [ ! -L $shtpasswd ]; then
+  ln -s $htpasswd $shtpasswd 
+fi
+if [ ! -L $shtaccess ]; then
 ln -s $htaccess $shtaccess
+fi
 
 # Restarting web server
 if [ "$restart" != 'no' ] && [ "$restart_required" = 'yes' ]; then

--- a/bin/v-delete-web-domain-httpauth
+++ b/bin/v-delete-web-domain-httpauth
@@ -23,7 +23,8 @@ source $VESTA/conf/vesta.conf
 # Defining htpasswd file
 htaccess="$HOMEDIR/$user/conf/web/$WEB_SYSTEM.$domain.conf_htaccess"
 htpasswd="$HOMEDIR/$user/conf/web/$WEB_SYSTEM.$domain.htpasswd"
-
+shtaccess="$HOMEDIR/$user/conf/web/s$WEB_SYSTEM.$domain.conf_htaccess"
+shtpasswd="$HOMEDIR/$user/conf/web/s$WEB_SYSTEM.$domain.htpasswd"
 
 #----------------------------------------------------------#
 #                    Verifications                         #
@@ -54,7 +55,7 @@ sed -i "/^$auth_user:/d" $htpasswd
 
 # Deleting password protection
 if [ "$(echo "$AUTH_USER" |tr : '\n' |wc -l)" -le 1 ]; then
-    rm -f $htaccess $htpasswd
+    rm -f $htaccess $htpasswd $shtaccess $shtpasswd
     restart_required='yes'
 fi
 


### PR DESCRIPTION
Issue Reference #872 
Permission error fixed for http auth config files.
Corrected missing secure template config files by symlinking http auth files.

open to consideration on best coding method to correct the errors described in tho Issue ticket.
Corrections to script fix the intended functions and makes this working on my system.
