### PR TITLE
web folder permission fix

### DIFF
--- a/bin/v-add-user
+++ b/bin/v-add-user
@@ -67,7 +67,6 @@ mkdir $HOMEDIR/$user/conf
 if [ ! -z "$WEB_SYSTEM" ]; then
     mkdir $HOMEDIR/$user/conf/web $HOMEDIR/$user/web $HOMEDIR/$user/tmp
     chmod 751 $HOMEDIR/$user/conf/web 
-    chmod 710 $HOMEDIR/$user/web
     chmod 700 $HOMEDIR/$user/tmp
     chown $user:$user $HOMEDIR/$user/web $HOMEDIR/$user/tmp
 fi


### PR DESCRIPTION
710 permission on /home/user/web (September 7 commit) is generating this Apache error on new users: 
Forbidden
You don't have permission to access /index.php on this server.
Server unable to read htaccess file, denying access to be safe