### PR TITLE
Update exim4.conf.template

### DIFF
--- a/install/debian/8/exim/exim4.conf.template
+++ b/install/debian/8/exim/exim4.conf.template
@@ -8,8 +8,8 @@
 #SPAM_SCORE = 50
 #CLAMD =  yes
 
-add_environment=<; PATH=/bin:/usr/bin
-keep_environment=
+MAIN_add_environment = <; PATH=/bin:/usr/bin
+MAIN_keep_environment=
 
 domainlist local_domains = dsearch;/etc/exim4/domains/
 domainlist relay_to_domains = dsearch;/etc/exim4/domains/


### PR DESCRIPTION
when using :
add_environment=<; PATH=/bin:/usr/bin
keep_environment=

exim can not start !

when change them to :
MAIN_add_environment = <; PATH=/bin:/usr/bin
MAIN_keep_environment=

it start normally with no errors . 

what you think ?

<<New configuration options
(keep_environment, add_environment) were introduced to adjust this
behavior. The debian configuration adds the macros MAIN_KEEP_ENVIRONMENT
and MAIN_ADD_ENVIRONMENT to easily set these options.>>