### PR TITLE
(RHEL7) Fix path in phpmyadmin.inc and fix static resources (css, js, imgs) not loading in RoundCube

### DIFF
--- a/install/rhel/7/nginx/phpmyadmin.inc
+++ b/install/rhel/7/nginx/phpmyadmin.inc
@@ -13,6 +13,6 @@ location /phpmyadmin {
         fastcgi_param SCRIPT_FILENAME $request_filename;
     }
     location ~* ^/phpmyadmin/(.+\.(jpg|jpeg|gif|css|png|js|ico|html|xml|txt))$ {
-        root /usr/share/;
+        alias /usr/share/phpMyAdmin/$1;
     }
 }

--- a/install/rhel/7/nginx/webmail.inc
+++ b/install/rhel/7/nginx/webmail.inc
@@ -12,4 +12,7 @@ location /webmail {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $request_filename;
     }
+    location ~* ^/webmail/(.+\.(jpg|jpeg|gif|css|png|js|ico|html|xml|txt))$ {
+        alias /usr/share/roundcubemail/$1;
+    }
 }


### PR DESCRIPTION
Recently I had a problem loading static resources (css, js, imgs) when accessing phpMyAdmin and RoundCube. I resolved the problems with the changes in this commit. The approach was similar to fdd35376f10dd208731bcd4e427ff2450ad07025 (didn't work on my CentOS7) but using the directive alias.