### PR TITLE
Fix #735 and #736 for centos

### DIFF
--- a/src/rpm/specs/vesta.spec
+++ b/src/rpm/specs/vesta.spec
@@ -39,6 +39,10 @@ if [ $1 -ge 2 ]; then
     if [ -e /usr/local/vesta/upd/fix_sessions.sh ]; then
         /usr/local/vesta/upd/fix_sessions.sh
     fi
+    xdd=$(which xxd)
+    if [ $? -gt 0 ]; then
+        yum install -y vim-common
+    fi
 fi
 %files
 %{_vestadir}


### PR DESCRIPTION
[root@home3 vesta]# v-add-letsencrypt-domain test test.com
/usr/local/vesta/bin/v-add-letsencrypt-user: regel 60: xxd: command not found
/usr/local/vesta/bin/v-add-letsencrypt-user: regel 64: xxd: command not found