### PR TITLE
Exclude comments

### DIFF
--- a/bin/v-add-sys-quota
+++ b/bin/v-add-sys-quota
@@ -38,7 +38,7 @@ fi
 
 # Adding group and user quota on /home partition
 mnt=$(df -P /home | awk '{print $6}' | tail -n1)
-lnr=$(cat -n /etc/fstab | awk '{print $1,$3}' | grep "$mnt$" | cut -f 1 -d ' ')
+lnr=$(cat -n /etc/fstab | grep -v "#" | awk '{print $1,$3}' | grep "$mnt$" | cut -f 1 -d ' ')
 opt=$(sed -n ${lnr}p /etc/fstab | awk '{print $4}')
 fnd='usrquota\|grpquota\|usrjquota=aquota.user\|grpjquota=aquota.group\|jqfmt=vfsv0'
 if [ $(echo $opt | tr ',' '\n' | grep -x $fnd | wc -l) -ne 5 ]; then


### PR DESCRIPTION
In ubuntu and debian, by default are some comments including partition and script get creazy

I explain problem here ( ithink affect only debian )

https://github.com/serghey-rodin/vesta/issues/844

I think nothing get broken, in may test working, ( debian 7 )

I try exclude # before all test but cat -n add numbers and not found any orther solution.