### PR TITLE
Фикс вывода ошибки о перезагрузке php-fpm

### DIFF
--- a/bin/v-restart-web-backend
+++ b/bin/v-restart-web-backend
@@ -57,7 +57,7 @@ else
     service $php_fpm restart >/dev/null 2>&1
 fi
 
-if [ $? -ne 0 ]; then
+if [ $? -ne 0 ] && [ $? -ne '0' ]; then
     send_email_report
     check_result $E_RESTART "$WEB_BACKEND restart failed"
 fi


### PR DESCRIPTION
В общем обновил я сервер до Ubuntu 16.04 с 14.04.
Установил PHP7 и в итоге в логах выводилось следующее:
```
root@rosa:/usr/local/vesta/bin# v-update-web-templates roland
0
Error: php-fpm restart failed
0
Error: php-fpm restart failed
0
Error: php-fpm restart failed
0
Error: php-fpm restart failed
0
Error: php-fpm restart failed
0
Error: php-fpm restart failed
0
Error: php-fpm restart failed
```
0 в данном случае это ```echo $?```
Добавив это условие вывод ошибки пропал.