### PR TITLE
Fix for mysql 5.7 when reset password

### DIFF
--- a/func/db.sh
+++ b/func/db.sh
@@ -263,10 +263,15 @@ change_mysql_password() {
     query="GRANT ALL ON \`$database\`.* TO \`$DBUSER\`@localhost
         IDENTIFIED BY '$dbpass'"
     mysql_query "$query" > /dev/null
-
-    query="SHOW GRANTS FOR '$DBUSER'"
-    md5=$(mysql_query "$query" 2>/dev/null)
-    md5=$(echo "$md5" |grep 'PASSWORD' |tr ' ' '\n' |tail -n1 |cut -f 2 -d \')
+    
+if [ "$(echo $mysql_ver |cut -d '.' -f2)" -ge 7 ]; then
+ 
+    md5=$(mysql_query "SHOW CREATE USER \`$DBUSER\`" 2>/dev/null)
+    md5=$(echo "$md5" |grep password |cut -f8 -d \')
+else
+    md5=$(mysql_query "SHOW GRANTS FOR \`$DBUSER\`" 2>/dev/null)
+    md5=$(echo "$md5" |grep PASSW|tr ' ' '\n' |tail -n1 |cut -f 2 -d \')
+fi
 }
 
 # Change PostgreSQL database password


### PR DESCRIPTION
Whit mysql 5.7 when reset password db.conf not get updated because cant get new md5 hash

This will fix it

I not touch GRANT ALL queryes because all working fine whit that part and all passwords was changed, but maybe you want change it.
I see this bug may afect this function:

dump_mysql_database() 

But I not know fot what is used grep -v "Grants for" > $grants

So I not touch it because not know how test it :)