### PR TITLE
New MySQL initialization

### DIFF
--- a/install/vst-install-ubuntu.sh
+++ b/install/vst-install-ubuntu.sh
@@ -935,9 +935,12 @@ if [ "$mysql" = 'yes' ]; then
 
     # Configuring MySQL/MariaDB
     wget $vestacp/mysql/$mycnf -O /etc/mysql/my.cnf
-    if [ "$release" != '16.04' ]; then
+    if [ "$release" >= '16.04' ]; then
+        mysqld --initialize
+    else
         mysql_install_db
     fi
+
     update-rc.d mysql defaults
     service mysql start
     check_result $? "mysql start failed"


### PR DESCRIPTION
Future Proofed MySQL.
At the very top of the official document you will notice that with the latest versions of MySQL the MySQL_Install_DB is depreciated.
http://dev.mysql.com/doc/refman/5.7/en/mysql-install-db.html

The new style initialization will only be used for newer versions of Ubuntu.
This patch aims to fix the newer versions of MySQL so that it uses the new syntax to initialize the DBs.