### PR TITLE
Force a new line, to prevent syntax errors.

### DIFF
--- a/bin/v-add-sys-sftp-jail
+++ b/bin/v-add-sys-sftp-jail
@@ -45,6 +45,7 @@ fi
 
 # Enabling jailed sftp
 if [ -z "$sftp_i" ]; then
+    echo " " >> $config
     echo "Subsystem sftp internal-sftp" >> $config
     echo "Match Group sftp-only" >> $config
     echo "ChrootDirectory /chroot/%u" >> $config


### PR DESCRIPTION
When I enabled SFTP chroot, "Subsystem sftp internal-sftp" was put directly after "UsePAM yes" (Ubuntu 16.04.1), which made "UsePAM yesSubsystem sftp internal-sftp", which obviously caused a syntax error. I fixed this by manually dividing those two options.