### PR TITLE
Let's Encrypt fixes for #979 (invalid response) and #1008 (/tmp/*/domain.tld.crt file not found)

### DIFF
--- a/bin/v-check-letsencrypt-domain
+++ b/bin/v-check-letsencrypt-domain
@@ -89,11 +89,15 @@ uri=$(echo "$answer" |grep -A 3 http-01 |grep uri |cut -f 4 -d \")
 # Adding location wrapper for request challenge
 if [ "$WEB_SYSTEM" = 'nginx' ] || [ "$PROXY_SYSTEM" = 'nginx' ]; then
     conf="$HOMEDIR/$user/conf/web/nginx.$r_domain.conf_letsencrypt"
+    sconf="$HOMEDIR/$user/conf/web/snginx.$r_domain.conf_letsencrypt"
     if [ ! -e "$conf" ]; then
         echo 'location ~ "^/\.well-known/acme-challenge/(.*)$" {' > $conf
         echo '    default_type text/plain;' >> $conf
         echo '    return 200 "$1.'$thumb'";' >> $conf
         echo '}' >> $conf
+    fi
+    if [ ! -e "$sconf" ]; then
+        ln -s "$conf" "$sconf"
     fi
 else
     acme="$HOMEDIR/$user/web/$r_domain/public_html/.well-known/acme-challenge"

--- a/web/edit/web/index.php
+++ b/web/edit/web/index.php
@@ -279,7 +279,7 @@ if (!empty($_POST['save'])) {
     }
 
     // Change SSL certificate
-    if (( $v_letsencrypt == 'no' ) && ( $v_ssl == 'yes' ) && (!empty($_POST['v_ssl'])) && (empty($_SESSION['error_msg']))) {
+    if (( $v_letsencrypt == 'no' ) && (empty($_POST['v_letsencrypt'])) && ( $v_ssl == 'yes' ) && (!empty($_POST['v_ssl'])) && (empty($_SESSION['error_msg']))) {
         if (( $v_ssl_crt != str_replace("\r\n", "\n",  $_POST['v_ssl_crt'])) || ( $v_ssl_key != str_replace("\r\n", "\n",  $_POST['v_ssl_key'])) || ( $v_ssl_ca != str_replace("\r\n", "\n",  $_POST['v_ssl_ca']))) {
             exec ('mktemp -d', $mktemp_output, $return_var);
             $tmpdir = $mktemp_output[0];


### PR DESCRIPTION
- If your domain is using `force-https` and is not currently working (pre-Let's Encrypt) with HTTPS, checking the "Let's Encrypt Support" box or doing it via the CLI will obviously not work. You'll need to get it working over HTTPS or switch away from the `force-https` template. Maybe there should be a warning of this somewhere but it's okay to assume the server admin has some level of competency.
- If your domain is currently working with HTTPS (say you're using a self signed certificate with CloudFlare in front of it giving it the facade of a valid certificate, or maybe you were previously using [vesta-letsencrypt](https://github.com/interbrite/letsencrypt-vesta) and the certificates are still valid) just checking "Let's Encrypt Support" seems to result in the `/tmp/tmp.*/domain.tld.crt not found` error regardless of using `force-https` or not. Ref: #1008
- If you're getting the /tmp error via the web interface and your site is currently accessible over HTTPS, running `v-add-letsencrypt-domain user domain [aliases] [restart] [notify]` seems to work just fine if you are not using `force-https`.
- If you are using `force-https` with nginx once you overcome the /tmp issue by either doing the command manually or patching the web interface you'll run into the "Invalid response" issue. This is also addressed below. Ref: #979

So why doesn't the web interface work when it should? It seems to be an issue with the block of code at [web/edit/web/index.php#L281](https://github.com/serghey-rodin/vesta/blob/7df680ae8311cea14efb18001758c31dd6268ef2/web/edit/web/index.php#L281) At first glance it would appear this code doesn't run due to the `$v_letsencrypt` check. But at this point `$v_letsencrypt` still equals `no` because that's not set to `yes` until line 373. By process of elimination we can assume the problem line is 311 since this is the only `exec` call in the block that is checked with `check_return_code`. Indeed, when we run that line manually we get the same error:
```
root@ubuntu:~# v-change-web-domain-sslcert user domain.tld /tmp/foobar no
Error: /tmp/foobar/domain.tld.crt not found
```
Looking at the code though, this failed operation shouldn't be too harmful. But it does prevent the execution of `v-add-letsencrypt-domain` on line 370 because the call to `check_return_code` sets the `$_SESSION['error_msg']` variable. Each block of code checks for this variable to stop executing (more or less) as soon as an error is detected.

The fix should be as simple as refusing to execute the "Change SSL certificate" block of code as long as `empty($_POST['v_letsencrypt'])`. An alternative solution could be re-ordering this block but given the way it's currently set up that could have some unforeseen consequences. This bug, while most readily exposed when using the `force-https` template, is not dependent on it and will occur if you simply already have HTTPS configured and try to switch to Let's Encrypt.

This finally gets us to the `Error: Invalid response from http://domain.tld/.well-known/acme-challenge/*` This, unlike the previous bug *is* dependent on the `force-https` template and will show itself both in the web interface and the CLI. If you are not using `force-https` or nginx hopefully everything is working by now. I have not tested this on Apache-only VestaCP installs but it looks like an issue only nginx will have. I've detailed the issue on https://github.com/serghey-rodin/vesta/issues/966#issuecomment-273680424. The fix I've proposed in this PR is to automate my symlink workaround described in the comment. I have yet to find any new bugs created by this symlink.