### PR TITLE
Add global flag for variables when backend config is generated

### DIFF
--- a/bin/v-add-web-domain-backend
+++ b/bin/v-add-web-domain-backend
@@ -57,8 +57,8 @@ done
 # Adding backend config
 cat $WEBTPL/$WEB_BACKEND/$template.tpl |\
     sed -e "s|%backend_port%|$backend_port|" \
-        -e "s|%user%|$user|"\
-        -e "s|%domain%|$domain|"\
+        -e "s|%user%|$user|g"\
+        -e "s|%domain%|$domain|g"\
         -e "s|%backend%|$backend_type|g" > $pool/$backend_type.conf
 
 

--- a/bin/v-change-web-domain-backend-tpl
+++ b/bin/v-change-web-domain-backend-tpl
@@ -62,8 +62,8 @@ done
 # Changing backend config
 cat $WEBTPL/$WEB_BACKEND/$template.tpl |\
     sed -e "s|%backend_port%|$backend_port|" \
-        -e "s|%user%|$user|"\
-        -e "s|%domain%|$domain|"\
+        -e "s|%user%|$user|g"\
+        -e "s|%domain%|$domain|g"\
         -e "s|%domain_idn%|$domain_idn|"\
         -e "s|%backend%|$backend_type|g" > $pool/$backend_type.conf
 


### PR DESCRIPTION
Variables $user and $domain should have a global flag in sed command when config is generated.

This gives more configuration options of backend (in my case php-fpm).

For example - configure open_basedir to each pool
```bash
php_admin_value[open_basedir] = /home/%user%/web/%domain%/public_html/:/home/%user%/web/%domain%/public_shtml/
```