### PR TITLE
Fix loss of the owner / group / permissions of the configuration file…

### DIFF
--- a/bin/v-change-sys-service-config
+++ b/bin/v-change-sys-service-config
@@ -104,7 +104,8 @@ if [ "$update" = 'yes' ] && [ "$restart" != 'no' ]; then
     service $service restart >/dev/null 2>&1
     if [ $? -ne 0 ]; then
         for config in $dst; do
-            mv -f $config.vst.back $config
+            cat $config.vst.back > $config
+            rm -f $config.vst.back
         done
         check_result $E_RESTART "$service failed to start with new config"
     fi


### PR DESCRIPTION
… while overwriting it

With use "mv" command, configuration file owner, group and permission  will become "root: root" with default permissions. This can lead to access problem, because a services will cannot access to the configuration file. For example, "named", will cannot restart, because required user "named" access to own configuration file.

"Cat" command, will be overwrite config file too, but it saves owner / group / permissions original file.