### PR TITLE
Remove trailing dot

### DIFF
--- a/bin/v-add-dns-record
+++ b/bin/v-add-dns-record
@@ -109,6 +109,16 @@ if [ ! -z "$DNS_CLUSTER" ]; then
     fi
 fi
 
+# remove trailing dot at the end of NS/CNAME/MX/PTR/SRV record
+
+if [[ $rtype =~ NS|CNAME|MX|PTR|SRV ]]; then
+    trailing_dot2=$(echo $record | grep "\.$")
+    if [ ! -z $trailing_dot2 ]; then
+        record=$(echo "${record::-1}")
+    fi
+fi
+
+
 
 #----------------------------------------------------------#
 #                       Vesta                              #


### PR DESCRIPTION
I check some servers and some times I see than cname not working, I check records and the problem is than some useres add record whit a dot ( in vesta GUI or CLI )

comerecord. in cname 2222 google.com

and vesta add it as it

cname.	14400	IN	CNAME		google.com.
test.	14400	IN	MX	10	mail.googl.com.

So whit this pull we remove that dot if added

hola	14400	IN	CNAME		test.net.
record	14400	IN	CNAME		hola.es.
recordar	14400	IN	CNAME		Tres.net.

This solve the dot but I think in a while loop, because vesta leave users add cname whit multiple dots:

Adding DNS Record → Record cname.......sdd.net has been created successfully.

Maybe vesta team have better solution for this one.