### PR TITLE
fixed typo for DKIM

### DIFF
--- a/bin/v-add-mail-domain-dkim
+++ b/bin/v-add-mail-domain-dkim
@@ -81,7 +81,7 @@ fi
 
 # Adding dkim in config
 update_object_value 'mail' 'DOMAIN' "$domain" '$DKIM' 'yes'
-increase_user_value "$user" '$U_MAIL_DKMI'
+increase_user_value "$user" '$U_MAIL_DKIM'
 
 # Logging
 log_history "enabled DKIM support for $domain"

--- a/bin/v-delete-mail-domain-dkim
+++ b/bin/v-delete-mail-domain-dkim
@@ -61,7 +61,7 @@ fi
 
 # Updatoing config
 update_object_value 'mail' 'DOMAIN' "$domain" '$DKIM' 'no'
-decrease_user_value "$user" '$U_MAIL_DKMI'
+decrease_user_value "$user" '$U_MAIL_DKIM'
 
 # Logging
 log_history "disabled DKIM support on $domain"


### PR DESCRIPTION
On update config for dkim add/remove
there is a typo.

# Updatoing config
update_object_value 'mail' 'DOMAIN' "$domain" '$DKIM' 'no'
decrease_user_value "$user" '$U_MAIL_DKMI'