### PR TITLE
Fix permissions issue ( security )

### DIFF
--- a/install/vst-install-rhel.sh
+++ b/install/vst-install-rhel.sh
@@ -1171,6 +1171,8 @@ if [ "$exim" = 'yes' ] && [ "$mysql" = 'yes' ]; then
     mysql -e "CREATE DATABASE roundcube"
     mysql -e "GRANT ALL ON roundcube.* TO roundcube@localhost IDENTIFIED BY '$r'"
     sed -i "s/%password%/$r/g" /etc/roundcubemail/config.inc.php
+    chmod 640 /etc/roundcubemail/config.inc.php
+    chown root:apache /etc/roundcubemail/config.inc.php
     if [ -e "/usr/share/roundcubemail/SQL/mysql.initial.sql" ]; then
         mysql roundcube < /usr/share/roundcubemail/SQL/mysql.initial.sql
     else


### PR DESCRIPTION
Same issue happen in debian, in my centos 6 installs always get /etc/roundcubemail/config.inc.php whit 644 whit roundcube password exposed.

In centos bad user:group is asigned so also fixed

This will be fixed in general update in current installed vestacp servers.