### PR TITLE
Fix permission ( security issue )

### DIFF
--- a/install/vst-install-debian.sh
+++ b/install/vst-install-debian.sh
@@ -1088,6 +1088,9 @@ if [ "$exim" = 'yes' ] && [ "$mysql" = 'yes' ]; then
     fi
     wget $vestacp/roundcube/main.inc.php -O /etc/roundcube/main.inc.php
     wget $vestacp/roundcube/db.inc.php -O /etc/roundcube/db.inc.php
+    chmod 640 /etc/roundcube/debian-db-roundcube.php
+    chmod 640 /etc/roundcube/config.inc.php
+    chown root:www-data /etc/roundcube/debian-db-roundcube.php
     wget $vestacp/roundcube/vesta.php -O \
         /usr/share/roundcube/plugins/password/drivers/vesta.php
     wget $vestacp/roundcube/config.inc.php -O \
@@ -1102,7 +1105,9 @@ if [ "$exim" = 'yes' ] && [ "$mysql" = 'yes' ]; then
     if [ "$release" -eq 8 ]; then
         mv -f /etc/roundcube/main.inc.php /etc/roundcube/config.inc.php
         mv -f /etc/roundcube/db.inc.php /etc/roundcube/debian-db-roundcube.php
-
+        chmod 640 /etc/roundcube/debian-db-roundcube.php
+        chmod 640 /etc/roundcube/config.inc.php
+        chown root:www-data /etc/roundcube/debian-db-roundcube.php
         # RoundCube tinyMCE fix
         tinymceFixArchiveURL=$vestacp/roundcube/roundcube-tinymce.tar.gz
         tinymceParentFolder=/usr/share/roundcube/program/js


### PR DESCRIPTION
In my debian 8 installs always /etc/roundcube/debian-db-roundcube.php has 644

/etc/roundcube/config.inc.php its ok 

But both files has roundcube mysql passwords and any one can read it.

I not know why are two files whit passwords one have correct permisions but fix bot 

I apply also for debian 7 but not sure if is affected