### PR TITLE
Fix DNS issue whit some characters

### DIFF
--- a/func/main.sh
+++ b/func/main.sh
@@ -594,9 +594,24 @@ is_common_format_valid() {
         check_result $E_INVALID "invalid $2 format :: $1"
     fi
     if [[ $1 =~ \* ]]; then
-        if [ "$(echo $1 | grep -o '*'|wc -l)" -gt 1 ]; then
-            check_result $E_INVALID "invalid $2 format :: $1"
+        if [[ "$(echo $1 | grep -o \*\. |wc -l)" -eq 0 ]] && [[ $1 != '*' ]] ; then
+                        check_result $E_INVALID "invalid $2 format :: $1"
         fi
+    fi
+    if [[ $(echo -n "$1" | tail -c 1) =~ [^a-zA-Z0-9_*@] ]]; then
+           check_result $E_INVALID "invalid $2 format :: $1"
+    fi
+    if [[ $(echo -n "$1" | grep -c '\.\.') -gt 0 ]];then
+           check_result $E_INVALID "invalid $2 format :: $1"
+    fi
+    if [[ $(echo -n "$1" | head -c 1) =~ [^a-zA-Z0-9_*@] ]]; then
+           check_result $E_INVALID "invalid $2 format :: $1"
+    fi
+    if [[ $(echo -n "$1" | grep -c '\-\-') -gt 0 ]]; then
+           check_result $E_INVALID "invalid $2 format :: $1"
+    fi
+    if [[ $(echo -n "$1" | grep -c '\_\_') -gt 0 ]]; then
+           check_result $E_INVALID "invalid $2 format :: $1"
     fi
 }
 

--- a/func/main.sh
+++ b/func/main.sh
@@ -594,7 +594,7 @@ is_common_format_valid() {
         check_result $E_INVALID "invalid $2 format :: $1"
     fi
     if [[ $1 =~ \* ]]; then
-        if [[ "$(echo $1 | grep -o \*\. |wc -l)" -eq 0 ]] && [[ $1 != '*' ]] ; then
+        if [[ "$(echo $1 | grep -o '\*\.' |wc -l)" -eq 0 ]] && [[ $1 != '*' ]] ; then
                         check_result $E_INVALID "invalid $2 format :: $1"
         fi
     fi


### PR DESCRIPTION
This will fix issues commented here: https://github.com/serghey-rodin/vesta/issues/1087

Changes:
1- Prevent user to add record as: record* or ** or *record only can add record if has * or *. so only valid wildcards
2- Prevent add like record. record.. record-- record-
3- Prevent add records like -record .record and leave user add _record needed for dmarc, dkim and orther
4- prevent add dual special characters like ..record or record--record or record__record or record........record