### PR TITLE
Fix fclose() incorrect variable

### DIFF
--- a/web/edit/server/apache2/index.php
+++ b/web/edit/server/apache2/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." apache2 ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/bind9/index.php
+++ b/web/edit/server/bind9/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_options']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." bind9-opt ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);
@@ -43,7 +43,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." bind9 ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/clamd/index.php
+++ b/web/edit/server/clamd/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." clamd ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/cron/index.php
+++ b/web/edit/server/cron/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." cron ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/crond/index.php
+++ b/web/edit/server/crond/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." crond ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/dovecot/index.php
+++ b/web/edit/server/dovecot/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." dovecot ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);
@@ -43,7 +43,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config1']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." dovecot-1 " .$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);
@@ -56,7 +56,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config2']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." dovecot-2 " .$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);
@@ -69,7 +69,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config3']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." dovecot-3 " .$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);
@@ -82,7 +82,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config4']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." dovecot-4 " .$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);
@@ -95,7 +95,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config5']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." dovecot-5 " .$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);
@@ -108,7 +108,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config6']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." dovecot-6 " .$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);
@@ -121,7 +121,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config7']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." dovecot-7 " .$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);
@@ -134,7 +134,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config8']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." dovecot-8 " .$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/exim/index.php
+++ b/web/edit/server/exim/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." exim ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/exim4/index.php
+++ b/web/edit/server/exim4/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." exim4 ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/fail2ban/index.php
+++ b/web/edit/server/fail2ban/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." fail2ban ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/httpd/index.php
+++ b/web/edit/server/httpd/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." httpd ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/mariadb/index.php
+++ b/web/edit/server/mariadb/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." mariadb ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/mysql/index.php
+++ b/web/edit/server/mysql/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." mysql ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/mysqld/index.php
+++ b/web/edit/server/mysqld/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." mysqld ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/named/index.php
+++ b/web/edit/server/named/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." named ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/nginx/index.php
+++ b/web/edit/server/nginx/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." nginx ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/php-fpm/index.php
+++ b/web/edit/server/php-fpm/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." php ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/php/index.php
+++ b/web/edit/server/php/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." php ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/php5-fpm/index.php
+++ b/web/edit/server/php5-fpm/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." php ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/postgresql/index.php
+++ b/web/edit/server/postgresql/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_options']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." postgresql-hba ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/proftpd/index.php
+++ b/web/edit/server/proftpd/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." proftpd ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/spamassassin/index.php
+++ b/web/edit/server/spamassassin/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." spamassassin ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/spamd/index.php
+++ b/web/edit/server/spamd/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." spamd ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);

--- a/web/edit/server/vsftpd/index.php
+++ b/web/edit/server/vsftpd/index.php
@@ -30,7 +30,7 @@ if (!empty($_POST['save'])) {
         $new_conf = $mktemp_output[0];
         $fp = fopen($new_conf, 'w');
         fwrite($fp, str_replace("\r\n", "\n",  $_POST['v_config']));
-        fclose($new_conf);
+        fclose($fp);
         exec (VESTA_CMD."v-change-sys-service-config ".$new_conf." vsftpd ".$v_restart, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);


### PR DESCRIPTION
Upon saving any settings under https://localhost:8083/edit/server/ a warning will appear 

> Warning: fclose() expects parameter 1 to be resource, string given in /usr/local/vesta/web/edit/server/*/index.php

 `fclose()` is using the incorrect variable ` $new_conf` should be `$fp` to properly close ` fopen` freeing up memory.