### PR TITLE
Patch insecure CSRF token crypto vulnerability

### DIFF
--- a/web/inc/main.php
+++ b/web/inc/main.php
@@ -59,10 +59,10 @@ if ((!isset($_SESSION['user'])) && (!defined('NO_AUTH_REQUIRED'))) {
     exit;
 }
 
+// Generate CSRF token
 if (isset($_SESSION['user'])) {
     if(!isset($_SESSION['token'])){
-        $token = uniqid(mt_rand(), true);
-        $_SESSION['token'] = $token;
+        $_SESSION['token'] = bin2hex(openssl_random_pseudo_bytes(16));
     }
 }
 

--- a/web/login/index.php
+++ b/web/login/index.php
@@ -126,7 +126,7 @@ if (empty($_SESSION['language'])) {
 }
 
 // Generate CSRF token
-$_SESSION['token'] = md5(uniqid(mt_rand(), true));
+$_SESSION['token'] = bin2hex(openssl_random_pseudo_bytes(16)); // generate 32-character cryptographically secure token
 
 require_once($_SERVER['DOCUMENT_ROOT'].'/inc/i18n/'.$_SESSION['language'].'.php');
 require_once('../templates/header.html');


### PR DESCRIPTION
I noticed that CSRF tokens are not using a cryptographically secure pseudorandom number generator. An attacker could potentially "guess" the CSRF token, allowing them to control vesta. The current algorithm for generating CSRF tokens is `md5(uniqid(mt_rand(), true))`, but it should use an algorithm that is considered cryptographically secure (for example, bin2hex(openssl_random_pseudo_bytes(32)) or bytes from /dev/urandom).

This pull request simply replaces the insecure crypto with the secure function.

To test if the code worked, I made this little script:
```
<?php
echo bin2hex(openssl_random_pseudo_bytes(16));
?>
```

The output is something like:
```
da202fd306550e3ad02fcbf2ac0838d4
```

The insecure algorithm (being used now) generates tokens like this:
```
11b1ec9936e32e555c7a32046871abc0
```

Same length, just more secure. Here's a stackoverflow post about it: http://stackoverflow.com/a/2595372

Also,
http://php.net/manual/en/function.mt-rand.php
http://php.net/manual/en/function.rand.php
If you scroll down on either of those documentation pages, you'll see the warning about how it does not generate cryptographically secure values.

Thanks!