### PR TITLE
Update v-list-sys-services  This fix detect another path for php-fpm, correctly detect service name

### DIFF
--- a/bin/v-list-sys-services
+++ b/bin/v-list-sys-services
@@ -153,7 +153,7 @@ fi
 
 # Checking WEB Backend
 if [ ! -z "$WEB_BACKEND" ] && [ "$WEB_BACKEND" != 'remote' ]; then
-    proc_name=$(ls /usr/sbin/php*fpm* |cut -f 4 -d /)
+    proc_name=$(ls /usr/sbin/php*fpm* | rev | cut -d'/' -f 1 | rev)
     get_srv_state $proc_name
     data="$data\nNAME='$WEB_BACKEND' SYSTEM='backend server' STATE='$state'"
     data="$data CPU='$cpu' MEM='$mem' RTIME='$rtime'"


### PR DESCRIPTION
correctly detect service name by '/' delimeter.
rev | cut -d'/' -f 1 | rev - get last field

This fix detect another path for php-fpm
ln -s /opt/remi/php70/root/usr/sbin/php-fpm /usr/sbin/php-fpm