### PR TITLE
fix pma tables

### DIFF
--- a/install/debian/8/pma/config.inc.php
+++ b/install/debian/8/pma/config.inc.php
@@ -76,18 +76,18 @@ if (!empty($dbname)) {
     $cfg['Servers'][$i]['controlpass'] = $dbpass;
     /* Optional: Advanced phpMyAdmin features */
     $cfg['Servers'][$i]['pmadb'] = $dbname;
-    $cfg['Servers'][$i]['bookmarktable'] = 'pma_bookmark';
-    $cfg['Servers'][$i]['relation'] = 'pma_relation';
-    $cfg['Servers'][$i]['table_info'] = 'pma_table_info';
-    $cfg['Servers'][$i]['table_coords'] = 'pma_table_coords';
-    $cfg['Servers'][$i]['pdf_pages'] = 'pma_pdf_pages';
-    $cfg['Servers'][$i]['column_info'] = 'pma_column_info';
-    $cfg['Servers'][$i]['history'] = 'pma_history';
-    $cfg['Servers'][$i]['table_uiprefs'] = 'pma_table_uiprefs';
-    $cfg['Servers'][$i]['designer_coords'] = 'pma_designer_coords';
-    $cfg['Servers'][$i]['tracking'] = 'pma_tracking';
-    $cfg['Servers'][$i]['userconfig'] = 'pma_userconfig';
-    $cfg['Servers'][$i]['recent'] = 'pma_recent';
+    $cfg['Servers'][$i]['bookmarktable'] = 'pma__bookmark';
+    $cfg['Servers'][$i]['relation'] = 'pma__relation';
+    $cfg['Servers'][$i]['table_info'] = 'pma__table_info';
+    $cfg['Servers'][$i]['table_coords'] = 'pma__table_coords';
+    $cfg['Servers'][$i]['pdf_pages'] = 'pma__pdf_pages';
+    $cfg['Servers'][$i]['column_info'] = 'pma__column_info';
+    $cfg['Servers'][$i]['history'] = 'pma__history';
+    $cfg['Servers'][$i]['table_uiprefs'] = 'pma__table_uiprefs';
+    $cfg['Servers'][$i]['designer_coords'] = 'pma__designer_coords';
+    $cfg['Servers'][$i]['tracking'] = 'pma__tracking';
+    $cfg['Servers'][$i]['userconfig'] = 'pma__userconfig';
+    $cfg['Servers'][$i]['recent'] = 'pma__recent';
 
     /* Uncomment the following to enable logging in to passwordless accounts,
      * after taking note of the associated security risks. */


### PR DESCRIPTION
change prefix pma tables - pma_ to pma__. After install and first login to phpmyadmin i can't open any table. After change prefix in config it works. more info http://stackoverflow.com/a/20731569/7363457