### PR TITLE
Add mail group to ssl files

### DIFF
--- a/bin/v-add-web-domain-ssl
+++ b/bin/v-add-web-domain-ssl
@@ -76,6 +76,8 @@ if [ -e "$ssl_dir/$domain.ca" ]; then
     cat $USER_DATA/ssl/$domain.ca >> $USER_DATA/ssl/$domain.pem
 fi
 chmod 660 $USER_DATA/ssl/$domain.*
+chown root:$user $HOMEDIR/$user/conf/web/ssl.$domain.key
+chown root:$user $HOMEDIR/$user/conf/web/ssl.$domain.pem
 
 # Adding certificate to user dir
 cp -f $USER_DATA/ssl/$domain.crt $HOMEDIR/$user/conf/web/ssl.$domain.crt

--- a/bin/v-add-web-domain-ssl
+++ b/bin/v-add-web-domain-ssl
@@ -76,8 +76,8 @@ if [ -e "$ssl_dir/$domain.ca" ]; then
     cat $USER_DATA/ssl/$domain.ca >> $USER_DATA/ssl/$domain.pem
 fi
 chmod 660 $USER_DATA/ssl/$domain.*
-chown root:$user $HOMEDIR/$user/conf/web/ssl.$domain.key
-chown root:$user $HOMEDIR/$user/conf/web/ssl.$domain.pem
+chown root:mail $HOMEDIR/$user/conf/web/ssl.$domain.key
+chown root:mail $HOMEDIR/$user/conf/web/ssl.$domain.pem
 
 # Adding certificate to user dir
 cp -f $USER_DATA/ssl/$domain.crt $HOMEDIR/$user/conf/web/ssl.$domain.crt


### PR DESCRIPTION
ssl files in user home dir are set to root:root, this causes the error when you try to use them with exim4 or dovecot:

`unable to open private key file for reading: /home/USER/conf/...`

for exim4 and dovecot you only need *.pem and *.key file. so im changing this file owners from root:root to root:mail.

if you manually change the permissions there will be set back again on next letsencrypt update, or custom ssl update.
