### PR TITLE
HTTPS links in the installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ssh root@your.server
 
 Download the installation script, and run it:
 ```bash
-curl http://vestacp.com/pub/vst-install.sh | bash
+curl https://vestacp.com/pub/vst-install.sh | bash
 ```
 
 How to install (3 step)
@@ -29,7 +29,7 @@ ssh root@your.server
 
 Download the installation script:
 ```bash
-curl -O http://vestacp.com/pub/vst-install.sh
+curl -O https://vestacp.com/pub/vst-install.sh
 ```
 Then run it:
 ```bash


### PR DESCRIPTION
Since VestaCP.com has a valid SSL certificate, it's nice to use it in the installation instructions too. Maybe also on the website?