### PR TITLE
Fix issue in v-letsencrypt-add-user

### DIFF
--- a/bin/v-add-letsencrypt-user
+++ b/bin/v-add-letsencrypt-user
@@ -55,7 +55,7 @@ if [ ! -e "$key" ]; then
 fi
 
 # Defining key exponent
-exponent=$(openssl pkey -inform perm -in "$key" -noout -text_pub |\
+exponent=$(openssl pkey -inform pem -in "$key" -noout -text_pub |\
     grep Exponent: |cut -f 2 -d '(' |cut -f 1 -d ')' |sed -e 's/x//' |\
     xxd -r -p |encode_base64)
 


### PR DESCRIPTION
`-inform **perm**` is not a valid openssl pkey option. This causes a `400: Registration Error`.
Simple typo, easily resolved. Some on the forum have been taking a sledgehammer to crack this nut (including statically linking the LetsEncrypt EULA) which will be fun the next time LE update the EULA.