### PR TITLE
Minor bug fix of v-sync-dns-cluster

### DIFF
--- a/bin/v-sync-dns-cluster
+++ b/bin/v-sync-dns-cluster
@@ -49,7 +49,7 @@ for cluster in $hosts; do
     check_result $? "$HOST connection failed" $E_CONNECT
 
     # Syncing user domains
-    user_list=$(ls $VESTA/data/users |grep -v "dns-cluster" |grep -v "history.log")
+    user_list=$(ls -d $VESTA/data/users/*/ | sed "s#$VESTA/data/users/##" | sed s"/.$//")
     for user in $user_list; do
         for str in $(cat $VESTA/data/users/$user/dns.conf); do
 

--- a/bin/v-sync-dns-cluster
+++ b/bin/v-sync-dns-cluster
@@ -49,7 +49,7 @@ for cluster in $hosts; do
     check_result $? "$HOST connection failed" $E_CONNECT
 
     # Syncing user domains
-    user_list=$(ls -d $VESTA/data/users/*/ | sed "s#$VESTA/data/users/##" | sed s"/.$//")
+    user_list=$(ls -d $VESTA/data/users/*/ | sed "s#$VESTA/data/users/##" | sed s"/.$//" | grep -v "dns-cluster")
     for user in $user_list; do
         for str in $(cat $VESTA/data/users/$user/dns.conf); do
 

--- a/bin/v-sync-dns-cluster
+++ b/bin/v-sync-dns-cluster
@@ -49,7 +49,7 @@ for cluster in $hosts; do
     check_result $? "$HOST connection failed" $E_CONNECT
 
     # Syncing user domains
-    user_list=$(ls $VESTA/data/users |grep -v "dns-cluster")
+    user_list=$(ls $VESTA/data/users |grep -v "dns-cluster" |grep -v "history.log")
     for user in $user_list; do
         for str in $(cat $VESTA/data/users/$user/dns.conf); do
 


### PR DESCRIPTION
Problem Outlined: It seems that another script has dropped a file called history.log into the $VESTA/data/users folder causing v-sync-dns-cluster to throw a soft error about not finding /usr/local/vesta/data/users/history.log/dns.conf when syncing zones.

Fix: Tell the script to ignore that log file when syncing user domains and the output becomes clean.


Preview of the log file:
<img width="572" alt="screen shot 2017-07-26 at 8 18 15 am" src="https://user-images.githubusercontent.com/8193597/28626474-4df7336e-71dc-11e7-92f4-86272bbd5ce7.png">

Preview showing before and after the fix has been applied:
<img width="571" alt="screen shot 2017-07-26 at 8 14 55 am" src="https://user-images.githubusercontent.com/8193597/28626525-74ce0c42-71dc-11e7-9279-db47c4aaa0f8.png">
