### PR TITLE
fix db.sh for postgres 9.5+

### DIFF
--- a/func/db.sh
+++ b/func/db.sh
@@ -88,7 +88,7 @@ psql_query() {
 }
 
 psql_dump() {
-    pg_dump -h $HOST -U $USER -c --inserts -O -x -i -f $1 $2 2>/tmp/e.psql
+    pg_dump -h $HOST -U $USER -c --inserts -O -x -f $1 $2 2>/tmp/e.psql
     if [ '0' -ne "$?" ]; then
         rm -rf $tmpdir
         if [ "$notify" != 'no' ]; then


### PR DESCRIPTION
Fixed backup function for postgres 9.5+ (removed "-i" option).
This option was deprecated in postgres 9.4 and removed from postgres 9.5.
This bug described in issue #913 and #1066 .
