### PR TITLE
Warning: autocreate plugin is deprecated, use mailbox { auto } setting instead

### DIFF
--- a/install/rhel/6/dovecot/conf.d/20-imap.conf
+++ b/install/rhel/6/dovecot/conf.d/20-imap.conf
@@ -3,18 +3,24 @@
 ##
 
 protocol imap {
-mail_plugins = $mail_plugins autocreate
-}
+  namespace inbox {
+    inbox = yes
 
-plugin {
-  autocreate = Trash
-  autocreate2 = Spam
-  autocreate3 = Sent
-  autocreate4 = Drafts
-  #autocreate5 = Custom
-  autosubscribe = Trash
-  autosubscribe2 = Spam
-  autosubscribe3 = Sent
-  autosubscribe4 = Drafts
-  #autosubscribe5 = Custom
+    mailbox Trash {
+      auto = subscribe #Autocreate/subscribe mailbox? no, create or subscribe values
+      special_use = \Trash
+    }
+    mailbox Sent {
+      auto = subscribe #Autocreate/subscribe mailbox? no, create or subscribe values
+      special_use = \Sent
+    }
+    mailbox Spam {
+      auto = subscribe #Autocreate/subscribe mailbox? no, create or subscribe values
+      special_use = \Junk
+    }
+    mailbox Drafts {
+      auto = subscribe #Autocreate/subscribe mailbox? no, create or subscribe values
+      special_use = \Drafts
+    }
+  }
 }

--- a/install/rhel/7/dovecot/conf.d/20-imap.conf
+++ b/install/rhel/7/dovecot/conf.d/20-imap.conf
@@ -3,18 +3,24 @@
 ##
 
 protocol imap {
-mail_plugins = $mail_plugins autocreate
-}
+  namespace inbox {
+    inbox = yes
 
-plugin {
-  autocreate = Trash
-  autocreate2 = Spam
-  autocreate3 = Sent
-  autocreate4 = Drafts
-  #autocreate5 = Custom
-  autosubscribe = Trash
-  autosubscribe2 = Spam
-  autosubscribe3 = Sent
-  autosubscribe4 = Drafts
-  #autosubscribe5 = Custom
+    mailbox Trash {
+      auto = subscribe #Autocreate/subscribe mailbox? no, create or subscribe values
+      special_use = \Trash
+    }
+    mailbox Sent {
+      auto = subscribe #Autocreate/subscribe mailbox? no, create or subscribe values
+      special_use = \Sent
+    }
+    mailbox Spam {
+      auto = subscribe #Autocreate/subscribe mailbox? no, create or subscribe values
+      special_use = \Junk
+    }
+    mailbox Drafts {
+      auto = subscribe #Autocreate/subscribe mailbox? no, create or subscribe values
+      special_use = \Drafts
+    }
+  }
 }


### PR DESCRIPTION
We could not login to the imap server after CentOS 7.4 updating. After this change, the problem was solved.

VestaCP Version: 0.9.8-17

Reference
https://wiki2.dovecot.org/MailboxSettings
https://serverfault.com/questions/763487/dovecot-autocreate-plugin-is-deprecated-use-mailbox-auto-setting