### PR TITLE
Fix delete includes in /etc/*/conf.d/vesta.conf for some usernames

### DIFF
--- a/bin/v-rebuild-web-domains
+++ b/bin/v-rebuild-web-domains
@@ -37,11 +37,11 @@ is_object_unsuspended 'user' 'USER' "$user"
 #----------------------------------------------------------#
 
 # Deleting old configs
-sed -i "/.*\/$user\//d" /etc/$WEB_SYSTEM/conf.d/vesta.conf
+sed -i "/.*\/$user\/conf\/web\//d" /etc/$WEB_SYSTEM/conf.d/vesta.conf
 rm -f $HOMEDIR/$user/conf/web/$WEB_SYSTEM.conf
 rm -f $HOMEDIR/$user/conf/web/s$WEB_SYSTEM.conf
 if [ ! -z "$PROXY_SYSTEM" ]; then
-    sed -i "/.*\/$user\//d" /etc/$PROXY_SYSTEM/conf.d/vesta.conf
+    sed -i "/.*\/$user\/conf\/web\//d" /etc/$PROXY_SYSTEM/conf.d/vesta.conf
     rm -f $HOMEDIR/$user/conf/web/$PROXY_SYSTEM.conf
     rm -f $HOMEDIR/$user/conf/web/s$PROXY_SYSTEM.conf
 fi

--- a/bin/v-rebuild-web-domains
+++ b/bin/v-rebuild-web-domains
@@ -36,15 +36,29 @@ is_object_unsuspended 'user' 'USER' "$user"
 #                       Action                             #
 #----------------------------------------------------------#
 
-# Deleting old configs
+# Deleting old web configs
 sed -i "/.*\/$user\/conf\/web\//d" /etc/$WEB_SYSTEM/conf.d/vesta.conf
-rm -f $HOMEDIR/$user/conf/web/$WEB_SYSTEM.conf
-rm -f $HOMEDIR/$user/conf/web/s$WEB_SYSTEM.conf
+if [ -e "$HOMEDIR/$user/conf/web/$WEB_SYSTEM.conf"  ]; then
+    rm $HOMEDIR/$user/conf/web/$WEB_SYSTEM.conf
+fi
+if [ -e "$HOMEDIR/$user/conf/web/s$WEB_SYSTEM.conf" ]; then
+    rm $HOMEDIR/$user/conf/web/s$WEB_SYSTEM.conf
+fi
+
+# Deleting old proxy configs
 if [ ! -z "$PROXY_SYSTEM" ]; then
     sed -i "/.*\/$user\/conf\/web\//d" /etc/$PROXY_SYSTEM/conf.d/vesta.conf
-    rm -f $HOMEDIR/$user/conf/web/$PROXY_SYSTEM.conf
-    rm -f $HOMEDIR/$user/conf/web/s$PROXY_SYSTEM.conf
+
+    if [ -e "$HOMEDIR/$user/conf/web/$PROXY_SYSTEM.conf" ]; then
+        rm $HOMEDIR/$user/conf/web/$PROXY_SYSTEM.conf
+    fi
+
+    if [ -e "$HOMEDIR/$user/conf/web/s$PROXY_SYSTEM.conf" ]; then
+        rm $HOMEDIR/$user/conf/web/s$PROXY_SYSTEM.conf
+    fi
 fi
+
+# Deleting backend configs
 if [ ! -z "$WEB_BACKEND" ]; then
     if [ "$WEB_BACKEND_POOL" = 'user' ]; then
         prepare_web_backend
@@ -61,7 +75,7 @@ fi
 for domain in $($BIN/v-list-web-domains $user plain |cut -f 1); do
     if [ ! -z "$WEB_BACKEND" ]; then
         template=$(get_object_value 'web' 'DOMAIN' "$domain" '$BACKEND')
-        $BIN/v-add-web-domain-backend $user $domain $template
+        $BIN/v-add-web-domain-backend $user $domain $template $restart
     fi
     rebuild_web_domain_conf
 done


### PR DESCRIPTION
If someone created an user named "conf" or "web", when that user rebuilt its web domains all lines with "include" on /etc/httpd/conf.d/vesta.conf and /etc/nginx/conf.d/vesta.conf for the virtualhosts would be deleted and then would only add its "include" rules.

The other users wouldn't have any website working anymore, they would have to rebuild their web domains to fix it.