### PR TITLE
Fix delete includes in /etc/*/conf.d/vesta.conf when deleting last domain

### DIFF
--- a/func/domain.sh
+++ b/func/domain.sh
@@ -258,7 +258,7 @@ replace_web_config() {
     sed -i  "$top_line,$bottom_line s|$old|$new|g" $conf
 }
 
-# Delete web configuartion
+# Delete web configuration
 del_web_config() {
     conf="$HOMEDIR/$user/conf/web/$1.conf"
     if [[ "$2" =~ stpl$ ]]; then
@@ -270,7 +270,7 @@ del_web_config() {
 
     web_domain=$(grep DOMAIN $USER_DATA/web.conf |wc -l)
     if [ "$web_domain" -eq '0' ]; then
-        sed -i "/.*\/$user\/.*$1.conf/d" /etc/$1/conf.d/vesta.conf
+        sed -i "/.*\/$user\/conf\/web\//d" /etc/$1/conf.d/vesta.conf
         rm -f $conf
     fi
 }


### PR DESCRIPTION
Same as #1293 , but in this case when the last domain for this user is deleted it would delete all includes for other users in vesta.conf