### PR TITLE
Duplicate interface name detection fix

### DIFF
--- a/bin/v-update-sys-ip
+++ b/bin/v-update-sys-ip
@@ -99,7 +99,7 @@ fi
 for ip in $ip_list; do
     check_ifconfig=$(/sbin/ifconfig |grep "$ip")
     if [ ! -e "$VESTA/data/ips/$ip" ] && [ ! -z "$check_ifconfig" ]; then
-        interface=$(/sbin/ip addr |grep $ip |awk '{print $NF}')
+        interface=$(/sbin/ip addr |grep $ip |awk '{print $NF}'|uniq)
         interface=$(echo "$interface" |cut -f 1 -d : |head -n 1)
         netmask=$(/sbin/ip addr |grep $ip |cut -f 2 -d / |cut -f 1 -d \ )
         netmask=$(convert_cidr $netmask)


### PR DESCRIPTION
When you install Vesta on Hetzner centos7 installation fails and returns error like this : "Error: user enp0s31f6 doesn't exist"

Network interface name finding mechanism returns 2 word and v-add-sys-ip command fails. 

/usr/local/vesta/bin/v-add-sys-ip 88.99.xxx.xxx 255.255.255.255 enp0s31f6 enp0s31f6