### PR TITLE
Fix charset in auto reply

### DIFF
--- a/install/rhel/7/exim/exim.conf
+++ b/install/rhel/7/exim/exim.conf
@@ -349,6 +349,7 @@ address_reply:
 userautoreply:
   driver = autoreply
   file = /etc/exim/domains/$domain/autoreply.${local_part}.msg
+  headers = Content-Type: text/plain; charset="UTF-8"
   from = "${local_part}@${domain}"
   headers = Content-Type: text/plain; charset=utf-8;\nContent-Transfer-Encoding: 8bit
   subject = "${if def:h_Subject: {Autoreply: \"${rfc2047:$h_Subject:}\"} {Autoreply Message}}"


### PR DESCRIPTION
This will fix broken charcteres in auto reply
To reproduce try set autoreply with special chacters í á ñ or something like that when you get reply you will see it broken in most cases