### PR TITLE
Addition of rewrite option for Wordpress for http and https

### DIFF
--- a/install/debian/7/templates/web/nginx/php5-fpm/wordpress.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/wordpress.stpl
@@ -13,6 +13,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/debian/7/templates/web/nginx/php5-fpm/wordpress.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/wordpress.tpl
@@ -9,6 +9,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/debian/7/templates/web/nginx/php5-fpm/wordpress2.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/wordpress2.stpl
@@ -23,6 +23,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/wordpress2.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/wordpress2.tpl
@@ -19,6 +19,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/wordpress.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/wordpress.stpl
@@ -13,6 +13,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/debian/8/templates/web/nginx/php5-fpm/wordpress.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/wordpress.tpl
@@ -9,6 +9,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/debian/8/templates/web/nginx/php5-fpm/wordpress2.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/wordpress2.stpl
@@ -23,6 +23,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/wordpress2.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/wordpress2.tpl
@@ -19,6 +19,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/wordpress.stpl
@@ -13,6 +13,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/rhel/5/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/wordpress.tpl
@@ -9,6 +9,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/rhel/5/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -23,6 +23,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -19,6 +19,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/wordpress.stpl
@@ -13,6 +13,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/rhel/6/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/wordpress.tpl
@@ -9,6 +9,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/rhel/6/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -23,6 +23,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -19,6 +19,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/wordpress.stpl
@@ -13,6 +13,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/rhel/7/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/wordpress.tpl
@@ -9,6 +9,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/rhel/7/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -23,6 +23,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -19,6 +19,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress.stpl
@@ -13,6 +13,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress.tpl
@@ -9,6 +9,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -23,6 +23,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -19,6 +19,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress.stpl
@@ -13,6 +13,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress.tpl
@@ -9,6 +9,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -23,6 +23,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -19,6 +19,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress.stpl
@@ -13,6 +13,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress.tpl
@@ -9,6 +9,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -23,6 +23,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -19,6 +19,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress.stpl
@@ -13,6 +13,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress.tpl
@@ -9,6 +9,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -23,6 +23,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -19,6 +19,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress.stpl
@@ -13,6 +13,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress.tpl
@@ -9,6 +9,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -23,6 +23,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -19,6 +19,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress.stpl
@@ -13,6 +13,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress.tpl
@@ -9,6 +9,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -23,6 +23,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -19,6 +19,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress.stpl
@@ -13,6 +13,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress.tpl
@@ -9,6 +9,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -23,6 +23,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -19,6 +19,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress.stpl
@@ -13,6 +13,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress.tpl
@@ -9,6 +9,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -23,6 +23,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -19,6 +19,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress.stpl
@@ -13,6 +13,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress.tpl
@@ -9,6 +9,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -23,6 +23,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -19,6 +19,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress.stpl
@@ -13,6 +13,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress.tpl
@@ -9,6 +9,11 @@ server {
 
     location / {
 
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
             expires     max;
         }

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -23,6 +23,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -19,6 +19,12 @@ server {
     }
 
     location / {
+
+        if (!-e $request_filename)
+        {
+                rewrite ^(.+)$ /index.php?q=$1 last;
+        }
+
         try_files $uri $uri/ /index.php?$args;
 
         location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {


### PR DESCRIPTION
Gentlemen,
I added rewrite opinion to Wordpress’ templates. Many of my clients have made complaints about the lack of this option. Without that option it was only possible to use url format example.com/?p=123 and because of adding this option it is possible to use example.com/contact. When can I expect to see this in the official version, so when I’ll be installing next installations next time I won’t have to modify the templates by hand.

