### PR TITLE
Add CAA DNS record

### DIFF
--- a/bin/v-add-dns-record
+++ b/bin/v-add-dns-record
@@ -45,10 +45,12 @@ if [[ $rtype =~ NS|CNAME|MX|PTR|SRV ]]; then
     fi
 fi
 
-dvalue=${dvalue//\"/}
+if [ $rtype != "CAA" ]; then
+    dvalue=${dvalue//\"/}
 
-if [[ "$dvalue" =~ [\;[:space:]] ]]; then
-    dvalue='"'"$dvalue"'"'
+    if [[ "$dvalue" =~ [\;[:space:]] ]]; then
+        dvalue='"'"$dvalue"'"'
+    fi
 fi
 
 # Additional argument formatting

--- a/func/main.sh
+++ b/func/main.sh
@@ -628,7 +628,7 @@ is_dbuser_format_valid() {
 
 # DNS record type validator
 is_dns_type_format_valid() {
-    known_dnstype='A,AAAA,NS,CNAME,MX,TXT,SRV,DNSKEY,KEY,IPSECKEY,PTR,SPF,TLSA'
+    known_dnstype='A,AAAA,NS,CNAME,MX,TXT,SRV,DNSKEY,KEY,IPSECKEY,PTR,SPF,TLSA,CAA'
     if [ -z "$(echo $known_dnstype |grep -w $1)" ]; then
         check_result $E_INVALID "invalid dns record type format :: $1"
     fi

--- a/web/templates/admin/add_dns_rec.html
+++ b/web/templates/admin/add_dns_rec.html
@@ -82,6 +82,7 @@
                                         <option value="PTR" <?php if ($v_type == 'PTR') echo selected; ?>>PTR</option>
                                         <option value="SPF" <?php if ($v_type == 'SPF') echo selected; ?>>SPF</option>
                                         <option value="TLSA" <?php if ($v_type == 'TLSA') echo selected; ?>>TLSA</option>
+                                        <option value="CAA" <?php if ($v_type == 'CAA') echo selected; ?>>CAA</option>
                                     </select>
                                 </td>
                             </tr>


### PR DESCRIPTION
A CAA DNS record is required for Letsencrypt.

More info:
https://letsencrypt.org/docs/caa/
https://sslmate.com/caa/support

Example:
domain.com.	IN	CAA	0 issue "letsencrypt.org"

In vesta:
v-add-dns-record 'admin' 'domainname.com' '@' 'CAA' '0 issue "letsencrypt.org"'

Maybe we can add this to the default template. Example: 
https://github.com/madeITBelgium/vesta/blob/master/install/rhel/7/templates/dns/default-letsencrypt.tpl#L22