### PR TITLE
public_html Permissions

### DIFF
--- a/bin/v-add-web-domain
+++ b/bin/v-add-web-domain
@@ -90,7 +90,7 @@ chown root:$user /var/log/$WEB_SYSTEM/domains/$domain.* $conf
 chmod 640 /var/log/$WEB_SYSTEM/domains/$domain.*
 chmod 751 $HOMEDIR/$user/web/$domain $HOMEDIR/$user/web/$domain/*
 chmod 551 $HOMEDIR/$user/web/$domain/stats $HOMEDIR/$user/web/$domain/logs
-chmod 644 $HOMEDIR/$user/web/$domain/public_*html/*
+chmod 755 $HOMEDIR/$user/web/$domain/public_*html/*
 
 # Addding PHP-FPM backend
 if [ ! -z "$WEB_BACKEND" ]; then


### PR DESCRIPTION
I believe 755 is the correct permission since 644 causes a lot of errors in the domain.error.log file.