### PR TITLE
#1429 fix php open_basedir error when using public_shtml as a document root

### DIFF
--- a/install/debian/7/templates/web/apache2/basedir.stpl
+++ b/install/debian/7/templates/web/apache2/basedir.stpl
@@ -15,7 +15,7 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"

--- a/install/debian/7/templates/web/apache2/hosting.stpl
+++ b/install/debian/7/templates/web/apache2/hosting.stpl
@@ -22,7 +22,7 @@
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>

--- a/install/debian/7/templates/web/apache2/phpcgi.stpl
+++ b/install/debian/7/templates/web/apache2/phpcgi.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php

--- a/install/debian/7/templates/web/apache2/phpfcgid.stpl
+++ b/install/debian/7/templates/web/apache2/phpfcgid.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>

--- a/install/debian/7/templates/web/nginx/hosting.stpl
+++ b/install/debian/7/templates/web/nginx/hosting.stpl
@@ -31,7 +31,7 @@ server {
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
 
-    disable_symlinks if_not_owner from=%docroot%;
+    disable_symlinks if_not_owner from=%sdocroot%;
 
     include %home%/%user%/conf/web/snginx.%domain%.conf*;
 }

--- a/install/debian/7/templates/web/nginx/php5-fpm/sendy.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/sendy.stpl
@@ -3,7 +3,7 @@ server {
     server_name %domain_idn% %alias_idn%;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/debian/7/templates/web/nginx/php5-fpm/wordpress2_rewrite.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/wordpress2_rewrite.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%web_ssl_port%;
     server_name %domain_idn% %alias_idn%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/debian/8/templates/web/apache2/basedir.stpl
+++ b/install/debian/8/templates/web/apache2/basedir.stpl
@@ -15,7 +15,7 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"

--- a/install/debian/8/templates/web/apache2/hosting.stpl
+++ b/install/debian/8/templates/web/apache2/hosting.stpl
@@ -22,7 +22,7 @@
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>

--- a/install/debian/8/templates/web/apache2/phpcgi.stpl
+++ b/install/debian/8/templates/web/apache2/phpcgi.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php

--- a/install/debian/8/templates/web/apache2/phpfcgid.stpl
+++ b/install/debian/8/templates/web/apache2/phpfcgid.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>

--- a/install/debian/8/templates/web/nginx/hosting.stpl
+++ b/install/debian/8/templates/web/nginx/hosting.stpl
@@ -31,7 +31,7 @@ server {
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
 
-    disable_symlinks if_not_owner from=%docroot%;
+    disable_symlinks if_not_owner from=%sdocroot%;
 
     include %home%/%user%/conf/web/snginx.%domain%.conf*;
 }

--- a/install/debian/8/templates/web/nginx/php5-fpm/sendy.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/sendy.stpl
@@ -3,7 +3,7 @@ server {
     server_name %domain_idn% %alias_idn%;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/debian/8/templates/web/nginx/php5-fpm/wordpress2_rewrite.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/wordpress2_rewrite.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%web_ssl_port%;
     server_name %domain_idn% %alias_idn%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/debian/9/templates/web/apache2/basedir.stpl
+++ b/install/debian/9/templates/web/apache2/basedir.stpl
@@ -15,7 +15,7 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"

--- a/install/debian/9/templates/web/apache2/hosting.stpl
+++ b/install/debian/9/templates/web/apache2/hosting.stpl
@@ -22,7 +22,7 @@
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>

--- a/install/debian/9/templates/web/apache2/phpcgi.stpl
+++ b/install/debian/9/templates/web/apache2/phpcgi.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php

--- a/install/debian/9/templates/web/apache2/phpfcgid.stpl
+++ b/install/debian/9/templates/web/apache2/phpfcgid.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>

--- a/install/debian/9/templates/web/nginx/hosting.stpl
+++ b/install/debian/9/templates/web/nginx/hosting.stpl
@@ -31,7 +31,7 @@ server {
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
 
-    disable_symlinks if_not_owner from=%docroot%;
+    disable_symlinks if_not_owner from=%sdocroot%;
 
     include %home%/%user%/conf/web/snginx.%domain%.conf*;
 }

--- a/install/debian/9/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/sendy.stpl
@@ -3,7 +3,7 @@ server {
     server_name %domain_idn% %alias_idn%;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/debian/9/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%web_ssl_port%;
     server_name %domain_idn% %alias_idn%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/rhel/5/templates/web/httpd/basedir.stpl
+++ b/install/rhel/5/templates/web/httpd/basedir.stpl
@@ -15,7 +15,7 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"

--- a/install/rhel/5/templates/web/httpd/hosting.stpl
+++ b/install/rhel/5/templates/web/httpd/hosting.stpl
@@ -22,7 +22,7 @@
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>

--- a/install/rhel/5/templates/web/httpd/phpcgi.stpl
+++ b/install/rhel/5/templates/web/httpd/phpcgi.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php

--- a/install/rhel/5/templates/web/httpd/phpfcgid.stpl
+++ b/install/rhel/5/templates/web/httpd/phpfcgid.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>

--- a/install/rhel/5/templates/web/nginx/hosting.stpl
+++ b/install/rhel/5/templates/web/nginx/hosting.stpl
@@ -31,7 +31,7 @@ server {
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
 
-    disable_symlinks if_not_owner from=%docroot%;
+    disable_symlinks if_not_owner from=%sdocroot%;
 
     include %home%/%user%/conf/web/snginx.%domain%.conf*;
 }

--- a/install/rhel/5/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/sendy.stpl
@@ -3,7 +3,7 @@ server {
     server_name %domain_idn% %alias_idn%;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/rhel/5/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%web_ssl_port%;
     server_name %domain_idn% %alias_idn%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/rhel/6/templates/web/httpd/basedir.stpl
+++ b/install/rhel/6/templates/web/httpd/basedir.stpl
@@ -15,7 +15,7 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"

--- a/install/rhel/6/templates/web/httpd/hosting.stpl
+++ b/install/rhel/6/templates/web/httpd/hosting.stpl
@@ -22,7 +22,7 @@
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>

--- a/install/rhel/6/templates/web/httpd/phpcgi.stpl
+++ b/install/rhel/6/templates/web/httpd/phpcgi.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php

--- a/install/rhel/6/templates/web/httpd/phpfcgid.stpl
+++ b/install/rhel/6/templates/web/httpd/phpfcgid.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>

--- a/install/rhel/6/templates/web/nginx/hosting.stpl
+++ b/install/rhel/6/templates/web/nginx/hosting.stpl
@@ -31,7 +31,7 @@ server {
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
 
-    disable_symlinks if_not_owner from=%docroot%;
+    disable_symlinks if_not_owner from=%sdocroot%;
 
     include %home%/%user%/conf/web/snginx.%domain%.conf*;
 }

--- a/install/rhel/6/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/sendy.stpl
@@ -3,7 +3,7 @@ server {
     server_name %domain_idn% %alias_idn%;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/rhel/6/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%web_ssl_port%;
     server_name %domain_idn% %alias_idn%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/rhel/7/templates/web/httpd/basedir.stpl
+++ b/install/rhel/7/templates/web/httpd/basedir.stpl
@@ -15,7 +15,7 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"

--- a/install/rhel/7/templates/web/httpd/hosting.stpl
+++ b/install/rhel/7/templates/web/httpd/hosting.stpl
@@ -22,7 +22,7 @@
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>

--- a/install/rhel/7/templates/web/httpd/phpcgi.stpl
+++ b/install/rhel/7/templates/web/httpd/phpcgi.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php

--- a/install/rhel/7/templates/web/httpd/phpfcgid.stpl
+++ b/install/rhel/7/templates/web/httpd/phpfcgid.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>

--- a/install/rhel/7/templates/web/nginx/hosting.stpl
+++ b/install/rhel/7/templates/web/nginx/hosting.stpl
@@ -31,7 +31,7 @@ server {
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
 
-    disable_symlinks if_not_owner from=%docroot%;
+    disable_symlinks if_not_owner from=%sdocroot%;
 
     include %home%/%user%/conf/web/snginx.%domain%.conf*;
 }

--- a/install/rhel/7/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/sendy.stpl
@@ -3,7 +3,7 @@ server {
     server_name %domain_idn% %alias_idn%;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/rhel/7/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%web_ssl_port%;
     server_name %domain_idn% %alias_idn%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/12.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/12.04/templates/web/apache2/basedir.stpl
@@ -15,7 +15,7 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"

--- a/install/ubuntu/12.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/12.04/templates/web/apache2/hosting.stpl
@@ -22,7 +22,7 @@
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>

--- a/install/ubuntu/12.04/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/12.04/templates/web/apache2/phpcgi.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php

--- a/install/ubuntu/12.04/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/12.04/templates/web/apache2/phpfcgid.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>

--- a/install/ubuntu/12.04/templates/web/nginx/hosting.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/hosting.stpl
@@ -31,7 +31,7 @@ server {
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
 
-    disable_symlinks if_not_owner from=%docroot%;
+    disable_symlinks if_not_owner from=%sdocroot%;
 
     include %home%/%user%/conf/web/snginx.%domain%.conf*;
 }

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/sendy.stpl
@@ -3,7 +3,7 @@ server {
     server_name %domain_idn% %alias_idn%;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%web_ssl_port%;
     server_name %domain_idn% %alias_idn%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/12.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/12.10/templates/web/apache2/basedir.stpl
@@ -15,7 +15,7 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"

--- a/install/ubuntu/12.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/12.10/templates/web/apache2/hosting.stpl
@@ -22,7 +22,7 @@
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>

--- a/install/ubuntu/12.10/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/12.10/templates/web/apache2/phpcgi.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php

--- a/install/ubuntu/12.10/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/12.10/templates/web/apache2/phpfcgid.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>

--- a/install/ubuntu/12.10/templates/web/nginx/hosting.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/hosting.stpl
@@ -31,7 +31,7 @@ server {
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
 
-    disable_symlinks if_not_owner from=%docroot%;
+    disable_symlinks if_not_owner from=%sdocroot%;
 
     include %home%/%user%/conf/web/snginx.%domain%.conf*;
 }

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/sendy.stpl
@@ -3,7 +3,7 @@ server {
     server_name %domain_idn% %alias_idn%;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%web_ssl_port%;
     server_name %domain_idn% %alias_idn%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/13.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/13.04/templates/web/apache2/basedir.stpl
@@ -15,7 +15,7 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"

--- a/install/ubuntu/13.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/13.04/templates/web/apache2/hosting.stpl
@@ -22,7 +22,7 @@
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>

--- a/install/ubuntu/13.04/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/13.04/templates/web/apache2/phpcgi.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php

--- a/install/ubuntu/13.04/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/13.04/templates/web/apache2/phpfcgid.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>

--- a/install/ubuntu/13.04/templates/web/nginx/hosting.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/hosting.stpl
@@ -31,7 +31,7 @@ server {
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
 
-    disable_symlinks if_not_owner from=%docroot%;
+    disable_symlinks if_not_owner from=%sdocroot%;
 
     include %home%/%user%/conf/web/snginx.%domain%.conf*;
 }

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/sendy.stpl
@@ -3,7 +3,7 @@ server {
     server_name %domain_idn% %alias_idn%;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%web_ssl_port%;
     server_name %domain_idn% %alias_idn%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/13.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/13.10/templates/web/apache2/basedir.stpl
@@ -15,7 +15,7 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"

--- a/install/ubuntu/13.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/13.10/templates/web/apache2/hosting.stpl
@@ -22,7 +22,7 @@
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>

--- a/install/ubuntu/13.10/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/13.10/templates/web/apache2/phpcgi.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php

--- a/install/ubuntu/13.10/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/13.10/templates/web/apache2/phpfcgid.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>

--- a/install/ubuntu/13.10/templates/web/nginx/hosting.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/hosting.stpl
@@ -31,7 +31,7 @@ server {
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
 
-    disable_symlinks if_not_owner from=%docroot%;
+    disable_symlinks if_not_owner from=%sdocroot%;
 
     include %home%/%user%/conf/web/snginx.%domain%.conf*;
 }

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/sendy.stpl
@@ -3,7 +3,7 @@ server {
     server_name %domain_idn% %alias_idn%;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%web_ssl_port%;
     server_name %domain_idn% %alias_idn%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/14.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/14.04/templates/web/apache2/basedir.stpl
@@ -15,7 +15,7 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"

--- a/install/ubuntu/14.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/14.04/templates/web/apache2/hosting.stpl
@@ -22,7 +22,7 @@
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>

--- a/install/ubuntu/14.04/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/14.04/templates/web/apache2/phpcgi.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php

--- a/install/ubuntu/14.04/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/14.04/templates/web/apache2/phpfcgid.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>

--- a/install/ubuntu/14.04/templates/web/nginx/hosting.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/hosting.stpl
@@ -31,7 +31,7 @@ server {
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
 
-    disable_symlinks if_not_owner from=%docroot%;
+    disable_symlinks if_not_owner from=%sdocroot%;
 
     include %home%/%user%/conf/web/snginx.%domain%.conf*;
 }

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/sendy.stpl
@@ -3,7 +3,7 @@ server {
     server_name %domain_idn% %alias_idn%;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%web_ssl_port%;
     server_name %domain_idn% %alias_idn%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/14.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/14.10/templates/web/apache2/basedir.stpl
@@ -15,7 +15,7 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"

--- a/install/ubuntu/14.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/14.10/templates/web/apache2/hosting.stpl
@@ -22,7 +22,7 @@
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>

--- a/install/ubuntu/14.10/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/14.10/templates/web/apache2/phpcgi.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php

--- a/install/ubuntu/14.10/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/14.10/templates/web/apache2/phpfcgid.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>

--- a/install/ubuntu/14.10/templates/web/nginx/hosting.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/hosting.stpl
@@ -31,7 +31,7 @@ server {
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
 
-    disable_symlinks if_not_owner from=%docroot%;
+    disable_symlinks if_not_owner from=%sdocroot%;
 
     include %home%/%user%/conf/web/snginx.%domain%.conf*;
 }

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/sendy.stpl
@@ -3,7 +3,7 @@ server {
     server_name %domain_idn% %alias_idn%;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%web_ssl_port%;
     server_name %domain_idn% %alias_idn%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/15.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/15.04/templates/web/apache2/basedir.stpl
@@ -15,7 +15,7 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"

--- a/install/ubuntu/15.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/15.04/templates/web/apache2/hosting.stpl
@@ -22,7 +22,7 @@
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>

--- a/install/ubuntu/15.04/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/15.04/templates/web/apache2/phpcgi.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php

--- a/install/ubuntu/15.04/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/15.04/templates/web/apache2/phpfcgid.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>

--- a/install/ubuntu/15.04/templates/web/nginx/hosting.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/hosting.stpl
@@ -31,7 +31,7 @@ server {
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
 
-    disable_symlinks if_not_owner from=%docroot%;
+    disable_symlinks if_not_owner from=%sdocroot%;
 
     include %home%/%user%/conf/web/snginx.%domain%.conf*;
 }

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/sendy.stpl
@@ -3,7 +3,7 @@ server {
     server_name %domain_idn% %alias_idn%;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%web_ssl_port%;
     server_name %domain_idn% %alias_idn%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/15.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/15.10/templates/web/apache2/basedir.stpl
@@ -15,7 +15,7 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"

--- a/install/ubuntu/15.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/15.10/templates/web/apache2/hosting.stpl
@@ -22,7 +22,7 @@
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>

--- a/install/ubuntu/15.10/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/15.10/templates/web/apache2/phpcgi.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php

--- a/install/ubuntu/15.10/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/15.10/templates/web/apache2/phpfcgid.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>

--- a/install/ubuntu/15.10/templates/web/nginx/hosting.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/hosting.stpl
@@ -31,7 +31,7 @@ server {
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
 
-    disable_symlinks if_not_owner from=%docroot%;
+    disable_symlinks if_not_owner from=%sdocroot%;
 
     include %home%/%user%/conf/web/snginx.%domain%.conf*;
 }

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/sendy.stpl
@@ -3,7 +3,7 @@ server {
     server_name %domain_idn% %alias_idn%;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%web_ssl_port%;
     server_name %domain_idn% %alias_idn%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/16.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/16.04/templates/web/apache2/basedir.stpl
@@ -15,7 +15,7 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"

--- a/install/ubuntu/16.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/16.04/templates/web/apache2/hosting.stpl
@@ -22,7 +22,7 @@
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>

--- a/install/ubuntu/16.04/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/16.04/templates/web/apache2/phpcgi.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php

--- a/install/ubuntu/16.04/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/16.04/templates/web/apache2/phpfcgid.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>

--- a/install/ubuntu/16.04/templates/web/nginx/hosting.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/hosting.stpl
@@ -31,7 +31,7 @@ server {
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
 
-    disable_symlinks if_not_owner from=%docroot%;
+    disable_symlinks if_not_owner from=%sdocroot%;
 
     include %home%/%user%/conf/web/snginx.%domain%.conf*;
 }

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/sendy.stpl
@@ -3,7 +3,7 @@ server {
     server_name %domain_idn% %alias_idn%;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%web_ssl_port%;
     server_name %domain_idn% %alias_idn%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/16.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/16.10/templates/web/apache2/basedir.stpl
@@ -15,7 +15,7 @@
         AllowOverride All
         SSLRequireSSL
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"

--- a/install/ubuntu/16.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/16.10/templates/web/apache2/hosting.stpl
@@ -22,7 +22,7 @@
         php_admin_flag mysql.allow_persistent  off
         php_admin_flag safe_mode off
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>

--- a/install/ubuntu/16.10/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/16.10/templates/web/apache2/phpcgi.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php

--- a/install/ubuntu/16.10/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/16.10/templates/web/apache2/phpfcgid.stpl
@@ -15,7 +15,7 @@
         SSLRequireSSL
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value open_basedir %docroot%:%home%/%user%/tmp
+        php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>

--- a/install/ubuntu/16.10/templates/web/nginx/hosting.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/hosting.stpl
@@ -31,7 +31,7 @@ server {
     location ~ /\.hg/   {return 404;}
     location ~ /\.bzr/  {return 404;}
 
-    disable_symlinks if_not_owner from=%docroot%;
+    disable_symlinks if_not_owner from=%sdocroot%;
 
     include %home%/%user%/conf/web/snginx.%domain%.conf*;
 }

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/sendy.stpl
@@ -3,7 +3,7 @@ server {
     server_name %domain_idn% %alias_idn%;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%web_ssl_port%;
     server_name %domain_idn% %alias_idn%;
-    root        %docroot%;
+    root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;


### PR DESCRIPTION
replace docroot by sdocroot in file *.stpl templye for fix php open_base error 