### PR TITLE
Exim Banner will only show nameserver.

### DIFF
--- a/install/debian/7/exim/exim4.conf.template
+++ b/install/debian/7/exim/exim4.conf.template
@@ -34,6 +34,7 @@ tls_advertise_hosts = *
 tls_certificate = /usr/local/vesta/ssl/certificate.crt
 tls_privatekey = /usr/local/vesta/ssl/certificate.key
 
+smtp_banner = ${smtp_active_hostname}
 daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root

--- a/install/debian/8/exim/exim4.conf.template
+++ b/install/debian/8/exim/exim4.conf.template
@@ -37,6 +37,7 @@ tls_advertise_hosts = *
 tls_certificate = /usr/local/vesta/ssl/certificate.crt
 tls_privatekey = /usr/local/vesta/ssl/certificate.key
 
+smtp_banner = ${smtp_active_hostname}
 daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root

--- a/install/debian/9/exim/exim4.conf.template
+++ b/install/debian/9/exim/exim4.conf.template
@@ -37,6 +37,7 @@ tls_advertise_hosts = *
 tls_certificate = /usr/local/vesta/ssl/certificate.crt
 tls_privatekey = /usr/local/vesta/ssl/certificate.key
 
+smtp_banner = ${smtp_active_hostname}
 daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root

--- a/install/rhel/5/exim/exim.conf
+++ b/install/rhel/5/exim/exim.conf
@@ -33,6 +33,7 @@ tls_advertise_hosts = *
 tls_certificate = /usr/local/vesta/ssl/certificate.crt
 tls_privatekey = /usr/local/vesta/ssl/certificate.key
 
+smtp_banner = ${smtp_active_hostname}
 daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root

--- a/install/rhel/6/exim/exim.conf
+++ b/install/rhel/6/exim/exim.conf
@@ -34,6 +34,7 @@ tls_advertise_hosts = *
 tls_certificate = /usr/local/vesta/ssl/certificate.crt
 tls_privatekey = /usr/local/vesta/ssl/certificate.key
 
+smtp_banner = ${smtp_active_hostname}
 daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root

--- a/install/rhel/7/exim/exim.conf
+++ b/install/rhel/7/exim/exim.conf
@@ -36,6 +36,7 @@ tls_advertise_hosts = *
 tls_certificate = /usr/local/vesta/ssl/certificate.crt
 tls_privatekey = /usr/local/vesta/ssl/certificate.key
 
+smtp_banner = ${smtp_active_hostname}
 daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root

--- a/install/ubuntu/12.04/exim/exim4.conf.template
+++ b/install/ubuntu/12.04/exim/exim4.conf.template
@@ -37,6 +37,7 @@ tls_advertise_hosts = *
 tls_certificate = /usr/local/vesta/ssl/certificate.crt
 tls_privatekey = /usr/local/vesta/ssl/certificate.key
 
+smtp_banner = ${smtp_active_hostname}
 daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root

--- a/install/ubuntu/12.10/exim/exim4.conf.template
+++ b/install/ubuntu/12.10/exim/exim4.conf.template
@@ -37,6 +37,7 @@ tls_advertise_hosts = *
 tls_certificate = /usr/local/vesta/ssl/certificate.crt
 tls_privatekey = /usr/local/vesta/ssl/certificate.key
 
+smtp_banner = ${smtp_active_hostname}
 daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root

--- a/install/ubuntu/13.04/exim/exim4.conf.template
+++ b/install/ubuntu/13.04/exim/exim4.conf.template
@@ -37,6 +37,7 @@ tls_advertise_hosts = *
 tls_certificate = /usr/local/vesta/ssl/certificate.crt
 tls_privatekey = /usr/local/vesta/ssl/certificate.key
 
+smtp_banner = ${smtp_active_hostname}
 daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root

--- a/install/ubuntu/13.10/exim/exim4.conf.template
+++ b/install/ubuntu/13.10/exim/exim4.conf.template
@@ -37,6 +37,7 @@ tls_advertise_hosts = *
 tls_certificate = /usr/local/vesta/ssl/certificate.crt
 tls_privatekey = /usr/local/vesta/ssl/certificate.key
 
+smtp_banner = ${smtp_active_hostname}
 daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root

--- a/install/ubuntu/14.04/exim/exim4.conf.template
+++ b/install/ubuntu/14.04/exim/exim4.conf.template
@@ -37,6 +37,7 @@ tls_advertise_hosts = *
 tls_certificate = /usr/local/vesta/ssl/certificate.crt
 tls_privatekey = /usr/local/vesta/ssl/certificate.key
 
+smtp_banner = ${smtp_active_hostname}
 daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root

--- a/install/ubuntu/14.10/exim/exim4.conf.template
+++ b/install/ubuntu/14.10/exim/exim4.conf.template
@@ -37,6 +37,7 @@ tls_advertise_hosts = *
 tls_certificate = /usr/local/vesta/ssl/certificate.crt
 tls_privatekey = /usr/local/vesta/ssl/certificate.key
 
+smtp_banner = ${smtp_active_hostname}
 daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root

--- a/install/ubuntu/15.04/exim/exim4.conf.template
+++ b/install/ubuntu/15.04/exim/exim4.conf.template
@@ -37,6 +37,7 @@ tls_advertise_hosts = *
 tls_certificate = /usr/local/vesta/ssl/certificate.crt
 tls_privatekey = /usr/local/vesta/ssl/certificate.key
 
+smtp_banner = ${smtp_active_hostname}
 daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root

--- a/install/ubuntu/15.10/exim/exim4.conf.template
+++ b/install/ubuntu/15.10/exim/exim4.conf.template
@@ -37,6 +37,7 @@ tls_advertise_hosts = *
 tls_certificate = /usr/local/vesta/ssl/certificate.crt
 tls_privatekey = /usr/local/vesta/ssl/certificate.key
 
+smtp_banner = ${smtp_active_hostname}
 daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root

--- a/install/ubuntu/16.04/exim/exim4.conf.template
+++ b/install/ubuntu/16.04/exim/exim4.conf.template
@@ -37,6 +37,7 @@ tls_advertise_hosts = *
 tls_certificate = /usr/local/vesta/ssl/certificate.crt
 tls_privatekey = /usr/local/vesta/ssl/certificate.key
 
+smtp_banner = ${smtp_active_hostname}
 daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root

--- a/install/ubuntu/16.10/exim/exim4.conf.template
+++ b/install/ubuntu/16.10/exim/exim4.conf.template
@@ -37,6 +37,7 @@ tls_advertise_hosts = *
 tls_certificate = /usr/local/vesta/ssl/certificate.crt
 tls_privatekey = /usr/local/vesta/ssl/certificate.key
 
+smtp_banner = ${smtp_active_hostname}
 daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root


### PR DESCRIPTION
As everyone probably knows security is often a story of a multitude of little tweak and layer.

During the next few month (until summer probably) I will propose a bunch of little modification to make VestaCP and their host more secure.

## This one is simply about hiding Exim and his version.
It's not recommended to have no banner, so the nameserver will appear instead.