### PR TITLE
Allowing normal user to change proxy template

### DIFF
--- a/web/edit/web/index.php
+++ b/web/edit/web/index.php
@@ -230,8 +230,8 @@ if (!empty($_POST['save'])) {
         $restart_proxy = 'yes';
     }
 
-    // Change proxy template / Update extension list (admin only)
-    if ((!empty($_SESSION['PROXY_SYSTEM'])) && (!empty($v_proxy)) && (!empty($_POST['v_proxy'])) && (empty($_SESSION['error_msg'])) && ($_SESSION['user'] == 'admin')) {
+    // Change proxy template / Update extension list
+    if ((!empty($_SESSION['PROXY_SYSTEM'])) && (!empty($v_proxy)) && (!empty($_POST['v_proxy'])) && (empty($_SESSION['error_msg'])) ) {
         $ext = preg_replace("/\n/", " ", $_POST['v_proxy_ext']);
         $ext = preg_replace("/,/", " ", $ext);
         $ext = preg_replace('/\s+/', ' ',$ext);

--- a/web/templates/user/edit_web.html
+++ b/web/templates/user/edit_web.html
@@ -96,6 +96,30 @@
                                     <table style="display:<?php if (empty($v_proxy)) { echo 'none';} else {echo 'block';}?> ;" id="proxytable">
                                         <tr>
                                             <td class="vst-text input-label">
+                                                <?php print __('Proxy Template');?>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>
+                                                <select class="vst-list" name="v_proxy_template">
+                                                    <?php
+                                                        foreach ($proxy_templates as $key => $value) {
+                                                            echo "\t\t\t\t<option value=\"".htmlentities($value)."\"";
+                                                            $svalue = "'".$value."'";
+                                                            if ((!empty($v_proxy_template)) && ( $value == $v_proxy_template ) || ($svalue == $v_proxy_template)){
+                                                                echo ' selected' ;
+                                                            }
+                                                            if ((empty($v_proxy_template)) && ($value == 'default')){
+                                                                echo ' selected' ;
+                                                            }
+                                                            echo ">".htmlentities($value)."</option>\n";
+                                                        }
+                                                    ?>
+                                                </select>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td class="vst-text input-label">
                                                 <?php print __('Proxy Extensions');?>
                                             </td>
                                         </tr>


### PR DESCRIPTION
In my hosting company, users want to be able to choose 'force-https' proxy template, for example.
This modification allows it.

I asked once Serghey and Dmitry why this is allowed only to admin, is this a security problem if user can choose proxy template.
They didn't answer, probably they were too busy.
So I'm not sure why it's only allowed to admin, and is there a security problem if users can change proxy template to their sites - so that's why this modiffication goes as push request - so Serghey can review it.