### PR TITLE
Fix for empty web domain auth user

### DIFF
--- a/bin/v-add-web-domain
+++ b/bin/v-add-web-domain
@@ -157,7 +157,7 @@ date=$(echo "$time_n_date" |cut -f 2 -d \ )
 echo "DOMAIN='$domain' IP='$ip' IP6='' ALIAS='$ALIAS' TPL='$WEB_TEMPLATE'\
  SSL='no' SSL_HOME='same' LETSENCRYPT='no' FTP_USER='' FTP_MD5=''\
  BACKEND='$BACKEND_TEMPLATE' PROXY='$PROXY_TEMPLATE' PROXY_EXT='$PROXY_EXT'\
- STATS='' STATS_USER='' STATS_CRYPT='' U_DISK='0' U_BANDWIDTH='0'\
+ STATS='' STATS_USER='' STATS_CRYPT='' AUTH_USER='' U_DISK='0' U_BANDWIDTH='0'\
  SUSPENDED='no' TIME='$time' DATE='$date'" >> $USER_DATA/web.conf
 
 # Restarting web server


### PR DESCRIPTION
Fixes the well explained issue: https://github.com/serghey-rodin/vesta/issues/1436

Similar fix has been applied before to solve problems like the one described in the anterior issue. E.g: https://github.com/serghey-rodin/vesta/commit/b0c07020db79c39224b7d8d5fdf7934b8b1f80f9