### PR TITLE
Fixing SSL Certificate Authority / Intermediate's optionality

### DIFF
--- a/func/domain.sh
+++ b/func/domain.sh
@@ -311,12 +311,6 @@ is_web_domain_cert_valid() {
         check_result $E_INVALID "SSL Certificate is not valid"
     fi
 
-    if [ ! -z "$(echo $crt_vrf |grep 'unable to get local issuer')" ]; then
-        if [ ! -e "$ssl_dir/$domain.ca" ]; then
-            check_result $E_NOTEXIST "Certificate Authority not found"
-        fi
-    fi
-
     if [ -e "$ssl_dir/$domain.ca" ]; then
         s1=$(openssl x509 -text -in $ssl_dir/$domain.crt 2>/dev/null)
         s1=$(echo "$s1" |grep Issuer  |awk -F = '{print $6}' |head -n1)

--- a/install/debian/7/templates/web/nginx/php5-fpm/cms_made_simple.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/cms_made_simple.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/cms_made_simple.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/cms_made_simple.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/codeigniter2.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/codeigniter2.stpl
@@ -21,7 +21,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -35,8 +35,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -45,7 +45,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/codeigniter2.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/codeigniter2.tpl
@@ -17,7 +17,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -31,8 +31,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -41,7 +41,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/codeigniter3.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/codeigniter3.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/codeigniter3.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/codeigniter3.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/datalife_engine.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/datalife_engine.stpl
@@ -92,7 +92,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -101,8 +101,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -111,7 +111,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/datalife_engine.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/datalife_engine.tpl
@@ -88,7 +88,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -97,8 +97,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -107,7 +107,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/default.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/default.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/default.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/default.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/dokuwiki.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/dokuwiki.stpl
@@ -22,7 +22,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/dokuwiki.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/dokuwiki.tpl
@@ -18,7 +18,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/drupal6.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/drupal6.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/drupal6.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/drupal6.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/drupal7.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/drupal7.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/drupal7.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/drupal7.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/drupal8.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/drupal8.stpl
@@ -54,7 +54,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -76,8 +76,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -86,7 +86,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/drupal8.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/drupal8.tpl
@@ -51,7 +51,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -73,8 +73,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -83,7 +83,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/joomla.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/joomla.stpl
@@ -27,7 +27,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/joomla.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/joomla.tpl
@@ -23,7 +23,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/laravel.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/laravel.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/laravel.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/laravel.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -24,8 +24,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -34,7 +34,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/magento.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/magento.stpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     ssl         on;
@@ -146,8 +146,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/debian/7/templates/web/nginx/php5-fpm/magento.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/magento.tpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     access_log  /var/log/nginx/domains/%domain%.log combined;
@@ -142,8 +142,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/debian/7/templates/web/nginx/php5-fpm/modx.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/modx.stpl
@@ -36,15 +36,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/modx.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/modx.tpl
@@ -32,15 +32,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -49,7 +49,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/moodle.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/moodle.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -64,8 +64,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -74,7 +74,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/moodle.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/moodle.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -61,8 +61,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -71,7 +71,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/no-php.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/no-php.stpl
@@ -21,8 +21,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -31,7 +31,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/no-php.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/no-php.tpl
@@ -17,8 +17,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -27,7 +27,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/odoo.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/odoo.stpl
@@ -44,8 +44,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
     
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -54,7 +54,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/odoo.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/odoo.tpl
@@ -40,8 +40,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/opencart.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/opencart.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -38,8 +38,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -48,7 +48,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/debian/7/templates/web/nginx/php5-fpm/opencart.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/opencart.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/debian/7/templates/web/nginx/php5-fpm/owncloud.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/owncloud.stpl
@@ -27,7 +27,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -59,8 +59,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -69,7 +69,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/owncloud.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/owncloud.tpl
@@ -23,7 +23,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -55,8 +55,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -65,7 +65,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/piwik.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/piwik.stpl
@@ -29,7 +29,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,18 +37,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-        return 404; 
+        return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
         }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -57,7 +57,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/piwik.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/piwik.tpl
@@ -25,7 +25,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,18 +33,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-            return 404; 
+            return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/pyrocms.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/pyrocms.stpl
@@ -25,7 +25,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -40,8 +40,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/pyrocms.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/pyrocms.tpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -36,8 +36,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -46,7 +46,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/sendy.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/sendy.stpl
@@ -40,7 +40,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -67,8 +67,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/sendy.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/sendy.tpl
@@ -38,7 +38,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -65,8 +65,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/wordpress.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/wordpress.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/wordpress.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/wordpress.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/wordpress2.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/wordpress2.stpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/wordpress2.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/wordpress2.tpl
@@ -28,7 +28,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/wordpress2_rewrite.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/wordpress2_rewrite.stpl
@@ -37,7 +37,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/7/templates/web/nginx/php5-fpm/wordpress2_rewrite.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/wordpress2_rewrite.tpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/cms_made_simple.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/cms_made_simple.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/cms_made_simple.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/cms_made_simple.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/codeigniter2.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/codeigniter2.stpl
@@ -21,7 +21,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -35,8 +35,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -45,7 +45,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/codeigniter2.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/codeigniter2.tpl
@@ -17,7 +17,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -31,8 +31,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -41,7 +41,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/codeigniter3.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/codeigniter3.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/codeigniter3.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/codeigniter3.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/datalife_engine.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/datalife_engine.stpl
@@ -92,7 +92,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -101,8 +101,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -111,7 +111,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/datalife_engine.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/datalife_engine.tpl
@@ -88,7 +88,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -97,8 +97,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -107,7 +107,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/default.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/default.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/default.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/default.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/dokuwiki.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/dokuwiki.stpl
@@ -22,7 +22,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/dokuwiki.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/dokuwiki.tpl
@@ -18,7 +18,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/drupal6.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/drupal6.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/drupal6.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/drupal6.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/drupal7.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/drupal7.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/drupal7.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/drupal7.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/drupal8.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/drupal8.stpl
@@ -54,7 +54,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -76,8 +76,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -86,7 +86,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/drupal8.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/drupal8.tpl
@@ -51,7 +51,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -73,8 +73,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -83,7 +83,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/joomla.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/joomla.stpl
@@ -27,7 +27,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/joomla.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/joomla.tpl
@@ -23,7 +23,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/laravel.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/laravel.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/laravel.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/laravel.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -24,8 +24,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -34,7 +34,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/magento.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/magento.stpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     ssl         on;
@@ -146,8 +146,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/debian/8/templates/web/nginx/php5-fpm/magento.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/magento.tpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     access_log  /var/log/nginx/domains/%domain%.log combined;
@@ -142,8 +142,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/debian/8/templates/web/nginx/php5-fpm/modx.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/modx.stpl
@@ -36,15 +36,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/modx.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/modx.tpl
@@ -32,15 +32,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -49,7 +49,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/moodle.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/moodle.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -64,8 +64,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -74,7 +74,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/moodle.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/moodle.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -61,8 +61,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -71,7 +71,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/no-php.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/no-php.stpl
@@ -21,8 +21,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -31,7 +31,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/no-php.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/no-php.tpl
@@ -17,8 +17,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -27,7 +27,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/odoo.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/odoo.stpl
@@ -44,8 +44,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
     
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -54,7 +54,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/odoo.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/odoo.tpl
@@ -40,8 +40,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/opencart.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/opencart.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -38,8 +38,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -48,7 +48,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/debian/8/templates/web/nginx/php5-fpm/opencart.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/opencart.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/debian/8/templates/web/nginx/php5-fpm/owncloud.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/owncloud.stpl
@@ -27,7 +27,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -59,8 +59,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -69,7 +69,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/owncloud.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/owncloud.tpl
@@ -23,7 +23,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -55,8 +55,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -65,7 +65,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/piwik.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/piwik.stpl
@@ -29,7 +29,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,18 +37,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-        return 404; 
+        return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
         }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -57,7 +57,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/piwik.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/piwik.tpl
@@ -25,7 +25,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,18 +33,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-            return 404; 
+            return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/pyrocms.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/pyrocms.stpl
@@ -25,7 +25,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -40,8 +40,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/pyrocms.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/pyrocms.tpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -36,8 +36,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -46,7 +46,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/sendy.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/sendy.stpl
@@ -40,7 +40,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -67,8 +67,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/sendy.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/sendy.tpl
@@ -38,7 +38,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -65,8 +65,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/wordpress.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/wordpress.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/wordpress.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/wordpress.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/wordpress2.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/wordpress2.stpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/wordpress2.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/wordpress2.tpl
@@ -28,7 +28,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/wordpress2_rewrite.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/wordpress2_rewrite.stpl
@@ -37,7 +37,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/8/templates/web/nginx/php5-fpm/wordpress2_rewrite.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/wordpress2_rewrite.tpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/cms_made_simple.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/cms_made_simple.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/codeigniter2.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/codeigniter2.stpl
@@ -21,7 +21,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -35,8 +35,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -45,7 +45,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/codeigniter2.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/codeigniter2.tpl
@@ -17,7 +17,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -31,8 +31,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -41,7 +41,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/codeigniter3.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/codeigniter3.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/codeigniter3.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/codeigniter3.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -92,7 +92,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -101,8 +101,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -111,7 +111,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/datalife_engine.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/datalife_engine.tpl
@@ -88,7 +88,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -97,8 +97,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -107,7 +107,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/default.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/default.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/default.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/default.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -22,7 +22,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/dokuwiki.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/dokuwiki.tpl
@@ -18,7 +18,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/drupal6.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/drupal6.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/drupal6.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/drupal6.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/drupal7.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/drupal7.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/drupal7.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/drupal7.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/drupal8.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/drupal8.stpl
@@ -54,7 +54,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -76,8 +76,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -86,7 +86,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/drupal8.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/drupal8.tpl
@@ -51,7 +51,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -73,8 +73,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -83,7 +83,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/joomla.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/joomla.stpl
@@ -27,7 +27,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/joomla.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/joomla.tpl
@@ -23,7 +23,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/laravel.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/laravel.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/laravel.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -24,8 +24,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -34,7 +34,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/magento.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/magento.stpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     ssl         on;
@@ -146,8 +146,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/debian/9/templates/web/nginx/php-fpm/magento.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/magento.tpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     access_log  /var/log/nginx/domains/%domain%.log combined;
@@ -142,8 +142,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/debian/9/templates/web/nginx/php-fpm/modx.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/modx.stpl
@@ -36,15 +36,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/modx.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/modx.tpl
@@ -32,15 +32,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -49,7 +49,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/moodle.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -64,8 +64,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -74,7 +74,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/moodle.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/moodle.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -61,8 +61,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -71,7 +71,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/no-php.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/no-php.stpl
@@ -21,8 +21,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -31,7 +31,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/no-php.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/no-php.tpl
@@ -17,8 +17,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -27,7 +27,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/odoo.stpl
@@ -44,8 +44,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
     
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -54,7 +54,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/odoo.tpl
@@ -40,8 +40,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/opencart.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/opencart.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -38,8 +38,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -48,7 +48,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/debian/9/templates/web/nginx/php-fpm/opencart.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/opencart.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/debian/9/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/owncloud.stpl
@@ -27,7 +27,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -59,8 +59,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -69,7 +69,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/owncloud.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/owncloud.tpl
@@ -23,7 +23,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -55,8 +55,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -65,7 +65,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/piwik.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/piwik.stpl
@@ -29,7 +29,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,18 +37,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-        return 404; 
+        return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
         }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -57,7 +57,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/piwik.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/piwik.tpl
@@ -25,7 +25,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,18 +33,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-            return 404; 
+            return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -25,7 +25,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -40,8 +40,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/pyrocms.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/pyrocms.tpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -36,8 +36,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -46,7 +46,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/sendy.stpl
@@ -40,7 +40,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -67,8 +67,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/sendy.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/sendy.tpl
@@ -38,7 +38,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -65,8 +65,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/wordpress.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/wordpress.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -28,7 +28,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -37,7 +37,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/debian/9/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/cms_made_simple.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/cms_made_simple.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/codeigniter2.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/codeigniter2.stpl
@@ -21,7 +21,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -35,8 +35,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -45,7 +45,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/codeigniter2.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/codeigniter2.tpl
@@ -17,7 +17,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -31,8 +31,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -41,7 +41,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/codeigniter3.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/codeigniter3.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/codeigniter3.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/codeigniter3.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -92,7 +92,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -101,8 +101,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -111,7 +111,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/datalife_engine.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/datalife_engine.tpl
@@ -88,7 +88,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -97,8 +97,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -107,7 +107,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/default.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/default.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/default.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/default.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -22,7 +22,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/dokuwiki.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/dokuwiki.tpl
@@ -18,7 +18,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/drupal6.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/drupal6.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/drupal6.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/drupal6.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/drupal7.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/drupal7.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/drupal7.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/drupal7.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/drupal8.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/drupal8.stpl
@@ -54,7 +54,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -76,8 +76,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -86,7 +86,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/drupal8.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/drupal8.tpl
@@ -51,7 +51,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -73,8 +73,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -83,7 +83,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/joomla.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/joomla.stpl
@@ -27,7 +27,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/joomla.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/joomla.tpl
@@ -23,7 +23,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/laravel.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/laravel.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/laravel.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -24,8 +24,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -34,7 +34,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/magento.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/magento.stpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     ssl         on;
@@ -146,8 +146,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/rhel/5/templates/web/nginx/php-fpm/magento.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/magento.tpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     access_log  /var/log/nginx/domains/%domain%.log combined;
@@ -142,8 +142,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/rhel/5/templates/web/nginx/php-fpm/modx.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/modx.stpl
@@ -36,15 +36,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/modx.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/modx.tpl
@@ -32,15 +32,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -49,7 +49,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/moodle.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -64,8 +64,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -74,7 +74,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/moodle.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/moodle.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -61,8 +61,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -71,7 +71,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/no-php.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/no-php.stpl
@@ -21,8 +21,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -31,7 +31,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/no-php.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/no-php.tpl
@@ -17,8 +17,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -27,7 +27,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/odoo.stpl
@@ -44,8 +44,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
     
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -54,7 +54,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/odoo.tpl
@@ -40,8 +40,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/opencart.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/opencart.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -38,8 +38,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -48,7 +48,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/rhel/5/templates/web/nginx/php-fpm/opencart.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/opencart.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/rhel/5/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/owncloud.stpl
@@ -27,7 +27,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -59,8 +59,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -69,7 +69,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/owncloud.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/owncloud.tpl
@@ -23,7 +23,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -55,8 +55,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -65,7 +65,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/piwik.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/piwik.stpl
@@ -29,7 +29,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,18 +37,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-        return 404; 
+        return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
         }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -57,7 +57,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/piwik.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/piwik.tpl
@@ -25,7 +25,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,18 +33,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-            return 404; 
+            return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -25,7 +25,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -40,8 +40,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/pyrocms.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/pyrocms.tpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -36,8 +36,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -46,7 +46,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/sendy.stpl
@@ -40,7 +40,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -67,8 +67,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/sendy.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/sendy.tpl
@@ -38,7 +38,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -65,8 +65,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/wordpress.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/wordpress.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -28,7 +28,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -37,7 +37,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/5/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/cms_made_simple.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/cms_made_simple.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/codeigniter2.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/codeigniter2.stpl
@@ -21,7 +21,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -35,8 +35,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -45,7 +45,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/codeigniter2.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/codeigniter2.tpl
@@ -17,7 +17,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -31,8 +31,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -41,7 +41,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/codeigniter3.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/codeigniter3.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/codeigniter3.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/codeigniter3.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -92,7 +92,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -101,8 +101,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -111,7 +111,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/datalife_engine.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/datalife_engine.tpl
@@ -88,7 +88,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -97,8 +97,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -107,7 +107,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/default.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/default.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/default.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/default.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -22,7 +22,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/dokuwiki.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/dokuwiki.tpl
@@ -18,7 +18,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/drupal6.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/drupal6.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/drupal6.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/drupal6.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/drupal7.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/drupal7.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/drupal7.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/drupal7.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/drupal8.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/drupal8.stpl
@@ -54,7 +54,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -76,8 +76,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -86,7 +86,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/drupal8.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/drupal8.tpl
@@ -51,7 +51,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -73,8 +73,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -83,7 +83,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/joomla.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/joomla.stpl
@@ -27,7 +27,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/joomla.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/joomla.tpl
@@ -23,7 +23,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/laravel.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/laravel.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/laravel.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -24,8 +24,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -34,7 +34,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/magento.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/magento.stpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     ssl         on;
@@ -146,8 +146,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/rhel/6/templates/web/nginx/php-fpm/magento.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/magento.tpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     access_log  /var/log/nginx/domains/%domain%.log combined;
@@ -142,8 +142,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/rhel/6/templates/web/nginx/php-fpm/modx.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/modx.stpl
@@ -36,15 +36,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/modx.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/modx.tpl
@@ -32,15 +32,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -49,7 +49,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/moodle.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -64,8 +64,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -74,7 +74,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/moodle.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/moodle.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -61,8 +61,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -71,7 +71,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/no-php.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/no-php.stpl
@@ -21,8 +21,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -31,7 +31,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/no-php.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/no-php.tpl
@@ -17,8 +17,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -27,7 +27,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/odoo.stpl
@@ -44,8 +44,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
     
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -54,7 +54,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/odoo.tpl
@@ -40,8 +40,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/opencart.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/opencart.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -38,8 +38,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -48,7 +48,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/rhel/6/templates/web/nginx/php-fpm/opencart.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/opencart.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/rhel/6/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/owncloud.stpl
@@ -27,7 +27,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -59,8 +59,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -69,7 +69,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/owncloud.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/owncloud.tpl
@@ -23,7 +23,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -55,8 +55,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -65,7 +65,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/piwik.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/piwik.stpl
@@ -29,7 +29,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,18 +37,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-        return 404; 
+        return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
         }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -57,7 +57,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/piwik.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/piwik.tpl
@@ -25,7 +25,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,18 +33,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-            return 404; 
+            return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -25,7 +25,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -40,8 +40,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/pyrocms.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/pyrocms.tpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -36,8 +36,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -46,7 +46,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/sendy.stpl
@@ -40,7 +40,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -67,8 +67,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/sendy.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/sendy.tpl
@@ -38,7 +38,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -65,8 +65,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/wordpress.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/wordpress.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -28,7 +28,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -37,7 +37,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/6/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/cms_made_simple.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/cms_made_simple.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/codeigniter2.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/codeigniter2.stpl
@@ -21,7 +21,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -35,8 +35,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -45,7 +45,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/codeigniter2.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/codeigniter2.tpl
@@ -17,7 +17,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -31,8 +31,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -41,7 +41,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/codeigniter3.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/codeigniter3.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/codeigniter3.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/codeigniter3.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -92,7 +92,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -101,8 +101,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -111,7 +111,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/datalife_engine.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/datalife_engine.tpl
@@ -88,7 +88,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -97,8 +97,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -107,7 +107,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/default.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/default.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/default.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/default.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -22,7 +22,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/dokuwiki.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/dokuwiki.tpl
@@ -18,7 +18,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/drupal6.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/drupal6.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/drupal6.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/drupal6.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/drupal7.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/drupal7.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/drupal7.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/drupal7.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/drupal8.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/drupal8.stpl
@@ -54,7 +54,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -76,8 +76,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -86,7 +86,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/drupal8.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/drupal8.tpl
@@ -51,7 +51,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -73,8 +73,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -83,7 +83,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/joomla.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/joomla.stpl
@@ -27,7 +27,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/joomla.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/joomla.tpl
@@ -23,7 +23,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/laravel.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/laravel.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/laravel.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -24,8 +24,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -34,7 +34,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/magento.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/magento.stpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     ssl         on;
@@ -146,8 +146,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/rhel/7/templates/web/nginx/php-fpm/magento.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/magento.tpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     access_log  /var/log/nginx/domains/%domain%.log combined;
@@ -142,8 +142,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/rhel/7/templates/web/nginx/php-fpm/modx.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/modx.stpl
@@ -36,15 +36,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/modx.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/modx.tpl
@@ -32,15 +32,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -49,7 +49,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/moodle.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -64,8 +64,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -74,7 +74,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/moodle.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/moodle.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -61,8 +61,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -71,7 +71,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/no-php.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/no-php.stpl
@@ -21,8 +21,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -31,7 +31,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/no-php.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/no-php.tpl
@@ -17,8 +17,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -27,7 +27,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/odoo.stpl
@@ -44,8 +44,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
     
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -54,7 +54,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/odoo.tpl
@@ -40,8 +40,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/opencart.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/opencart.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -38,8 +38,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -48,7 +48,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/rhel/7/templates/web/nginx/php-fpm/opencart.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/opencart.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/rhel/7/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/owncloud.stpl
@@ -27,7 +27,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -59,8 +59,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -69,7 +69,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/owncloud.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/owncloud.tpl
@@ -23,7 +23,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -55,8 +55,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -65,7 +65,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/piwik.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/piwik.stpl
@@ -29,7 +29,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,18 +37,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-        return 404; 
+        return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
         }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -57,7 +57,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/piwik.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/piwik.tpl
@@ -25,7 +25,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,18 +33,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-            return 404; 
+            return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -25,7 +25,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -40,8 +40,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/pyrocms.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/pyrocms.tpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -36,8 +36,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -46,7 +46,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/sendy.stpl
@@ -40,7 +40,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -67,8 +67,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/sendy.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/sendy.tpl
@@ -38,7 +38,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -65,8 +65,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/wordpress.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/wordpress.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -28,7 +28,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -37,7 +37,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/rhel/7/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/cms_made_simple.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/cms_made_simple.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/codeigniter2.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/codeigniter2.stpl
@@ -21,7 +21,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -35,8 +35,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -45,7 +45,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/codeigniter2.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/codeigniter2.tpl
@@ -17,7 +17,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -31,8 +31,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -41,7 +41,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/codeigniter3.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/codeigniter3.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/codeigniter3.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/codeigniter3.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -92,7 +92,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -101,8 +101,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -111,7 +111,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/datalife_engine.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/datalife_engine.tpl
@@ -88,7 +88,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -97,8 +97,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -107,7 +107,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/default.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/default.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/default.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/default.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -22,7 +22,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/dokuwiki.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/dokuwiki.tpl
@@ -18,7 +18,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/drupal6.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/drupal6.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/drupal6.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/drupal6.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/drupal7.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/drupal7.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/drupal7.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/drupal7.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/drupal8.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/drupal8.stpl
@@ -54,7 +54,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -76,8 +76,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -86,7 +86,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/drupal8.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/drupal8.tpl
@@ -51,7 +51,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -73,8 +73,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -83,7 +83,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/joomla.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/joomla.stpl
@@ -27,7 +27,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/joomla.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/joomla.tpl
@@ -23,7 +23,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/laravel.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/laravel.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/laravel.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -24,8 +24,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -34,7 +34,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/magento.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/magento.stpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     ssl         on;
@@ -146,8 +146,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/magento.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/magento.tpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     access_log  /var/log/nginx/domains/%domain%.log combined;
@@ -142,8 +142,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/modx.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/modx.stpl
@@ -36,15 +36,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/modx.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/modx.tpl
@@ -32,15 +32,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -49,7 +49,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/moodle.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -64,8 +64,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -74,7 +74,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/moodle.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/moodle.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -61,8 +61,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -71,7 +71,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/no-php.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/no-php.stpl
@@ -21,8 +21,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -31,7 +31,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/no-php.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/no-php.tpl
@@ -17,8 +17,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -27,7 +27,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/odoo.stpl
@@ -44,8 +44,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
     
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -54,7 +54,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/odoo.tpl
@@ -40,8 +40,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/opencart.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/opencart.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -38,8 +38,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -48,7 +48,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/opencart.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/opencart.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/owncloud.stpl
@@ -27,7 +27,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -59,8 +59,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -69,7 +69,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/owncloud.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/owncloud.tpl
@@ -23,7 +23,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -55,8 +55,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -65,7 +65,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/piwik.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/piwik.stpl
@@ -29,7 +29,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,18 +37,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-        return 404; 
+        return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
         }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -57,7 +57,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/piwik.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/piwik.tpl
@@ -25,7 +25,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,18 +33,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-            return 404; 
+            return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -25,7 +25,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -40,8 +40,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/pyrocms.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/pyrocms.tpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -36,8 +36,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -46,7 +46,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/sendy.stpl
@@ -40,7 +40,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -67,8 +67,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/sendy.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/sendy.tpl
@@ -38,7 +38,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -65,8 +65,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -28,7 +28,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -37,7 +37,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/cms_made_simple.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/cms_made_simple.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/codeigniter2.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/codeigniter2.stpl
@@ -21,7 +21,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -35,8 +35,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -45,7 +45,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/codeigniter2.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/codeigniter2.tpl
@@ -17,7 +17,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -31,8 +31,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -41,7 +41,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/codeigniter3.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/codeigniter3.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/codeigniter3.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/codeigniter3.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -92,7 +92,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -101,8 +101,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -111,7 +111,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/datalife_engine.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/datalife_engine.tpl
@@ -88,7 +88,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -97,8 +97,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -107,7 +107,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/default.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/default.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/default.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/default.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -22,7 +22,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/dokuwiki.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/dokuwiki.tpl
@@ -18,7 +18,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/drupal6.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/drupal6.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/drupal6.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/drupal6.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/drupal7.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/drupal7.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/drupal7.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/drupal7.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/drupal8.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/drupal8.stpl
@@ -54,7 +54,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -76,8 +76,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -86,7 +86,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/drupal8.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/drupal8.tpl
@@ -51,7 +51,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -73,8 +73,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -83,7 +83,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/joomla.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/joomla.stpl
@@ -27,7 +27,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/joomla.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/joomla.tpl
@@ -23,7 +23,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/laravel.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/laravel.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/laravel.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -24,8 +24,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -34,7 +34,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/magento.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/magento.stpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     ssl         on;
@@ -146,8 +146,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/magento.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/magento.tpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     access_log  /var/log/nginx/domains/%domain%.log combined;
@@ -142,8 +142,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/modx.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/modx.stpl
@@ -36,15 +36,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/modx.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/modx.tpl
@@ -32,15 +32,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -49,7 +49,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/moodle.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -64,8 +64,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -74,7 +74,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/moodle.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/moodle.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -61,8 +61,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -71,7 +71,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/no-php.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/no-php.stpl
@@ -21,8 +21,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -31,7 +31,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/no-php.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/no-php.tpl
@@ -17,8 +17,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -27,7 +27,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/odoo.stpl
@@ -44,8 +44,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
     
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -54,7 +54,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/odoo.tpl
@@ -40,8 +40,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/opencart.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/opencart.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -38,8 +38,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -48,7 +48,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/opencart.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/opencart.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/owncloud.stpl
@@ -27,7 +27,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -59,8 +59,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -69,7 +69,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/owncloud.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/owncloud.tpl
@@ -23,7 +23,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -55,8 +55,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -65,7 +65,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/piwik.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/piwik.stpl
@@ -29,7 +29,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,18 +37,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-        return 404; 
+        return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
         }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -57,7 +57,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/piwik.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/piwik.tpl
@@ -25,7 +25,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,18 +33,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-            return 404; 
+            return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -25,7 +25,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -40,8 +40,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/pyrocms.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/pyrocms.tpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -36,8 +36,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -46,7 +46,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/sendy.stpl
@@ -40,7 +40,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -67,8 +67,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/sendy.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/sendy.tpl
@@ -38,7 +38,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -65,8 +65,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -28,7 +28,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -37,7 +37,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/cms_made_simple.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/cms_made_simple.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/codeigniter2.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/codeigniter2.stpl
@@ -21,7 +21,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -35,8 +35,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -45,7 +45,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/codeigniter2.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/codeigniter2.tpl
@@ -17,7 +17,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -31,8 +31,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -41,7 +41,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/codeigniter3.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/codeigniter3.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/codeigniter3.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/codeigniter3.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -92,7 +92,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -101,8 +101,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -111,7 +111,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/datalife_engine.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/datalife_engine.tpl
@@ -88,7 +88,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -97,8 +97,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -107,7 +107,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/default.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/default.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/default.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/default.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -22,7 +22,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/dokuwiki.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/dokuwiki.tpl
@@ -18,7 +18,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/drupal6.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/drupal6.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/drupal6.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/drupal6.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/drupal7.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/drupal7.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/drupal7.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/drupal7.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/drupal8.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/drupal8.stpl
@@ -54,7 +54,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -76,8 +76,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -86,7 +86,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/drupal8.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/drupal8.tpl
@@ -51,7 +51,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -73,8 +73,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -83,7 +83,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/joomla.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/joomla.stpl
@@ -27,7 +27,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/joomla.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/joomla.tpl
@@ -23,7 +23,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/laravel.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/laravel.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/laravel.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -24,8 +24,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -34,7 +34,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/magento.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/magento.stpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     ssl         on;
@@ -146,8 +146,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/magento.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/magento.tpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     access_log  /var/log/nginx/domains/%domain%.log combined;
@@ -142,8 +142,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/modx.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/modx.stpl
@@ -36,15 +36,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/modx.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/modx.tpl
@@ -32,15 +32,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -49,7 +49,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/moodle.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -64,8 +64,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -74,7 +74,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/moodle.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/moodle.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -61,8 +61,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -71,7 +71,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/no-php.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/no-php.stpl
@@ -21,8 +21,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -31,7 +31,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/no-php.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/no-php.tpl
@@ -17,8 +17,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -27,7 +27,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/odoo.stpl
@@ -44,8 +44,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
     
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -54,7 +54,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/odoo.tpl
@@ -40,8 +40,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/opencart.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/opencart.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -38,8 +38,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -48,7 +48,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/opencart.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/opencart.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/owncloud.stpl
@@ -27,7 +27,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -59,8 +59,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -69,7 +69,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/owncloud.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/owncloud.tpl
@@ -23,7 +23,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -55,8 +55,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -65,7 +65,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/piwik.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/piwik.stpl
@@ -29,7 +29,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,18 +37,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-        return 404; 
+        return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
         }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -57,7 +57,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/piwik.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/piwik.tpl
@@ -25,7 +25,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,18 +33,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-            return 404; 
+            return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -25,7 +25,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -40,8 +40,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/pyrocms.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/pyrocms.tpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -36,8 +36,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -46,7 +46,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/sendy.stpl
@@ -40,7 +40,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -67,8 +67,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/sendy.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/sendy.tpl
@@ -38,7 +38,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -65,8 +65,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -28,7 +28,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -37,7 +37,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/cms_made_simple.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/cms_made_simple.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/codeigniter2.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/codeigniter2.stpl
@@ -21,7 +21,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -35,8 +35,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -45,7 +45,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/codeigniter2.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/codeigniter2.tpl
@@ -17,7 +17,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -31,8 +31,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -41,7 +41,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/codeigniter3.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/codeigniter3.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/codeigniter3.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/codeigniter3.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -92,7 +92,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -101,8 +101,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -111,7 +111,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/datalife_engine.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/datalife_engine.tpl
@@ -88,7 +88,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -97,8 +97,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -107,7 +107,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/default.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/default.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/default.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/default.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -22,7 +22,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/dokuwiki.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/dokuwiki.tpl
@@ -18,7 +18,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/drupal6.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/drupal6.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/drupal6.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/drupal6.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/drupal7.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/drupal7.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/drupal7.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/drupal7.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/drupal8.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/drupal8.stpl
@@ -54,7 +54,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -76,8 +76,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -86,7 +86,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/drupal8.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/drupal8.tpl
@@ -51,7 +51,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -73,8 +73,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -83,7 +83,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/joomla.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/joomla.stpl
@@ -27,7 +27,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/joomla.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/joomla.tpl
@@ -23,7 +23,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/laravel.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/laravel.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/laravel.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -24,8 +24,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -34,7 +34,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/magento.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/magento.stpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     ssl         on;
@@ -146,8 +146,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/magento.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/magento.tpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     access_log  /var/log/nginx/domains/%domain%.log combined;
@@ -142,8 +142,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/modx.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/modx.stpl
@@ -36,15 +36,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/modx.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/modx.tpl
@@ -32,15 +32,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -49,7 +49,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/moodle.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -64,8 +64,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -74,7 +74,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/moodle.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/moodle.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -61,8 +61,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -71,7 +71,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/no-php.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/no-php.stpl
@@ -21,8 +21,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -31,7 +31,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/no-php.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/no-php.tpl
@@ -17,8 +17,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -27,7 +27,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/odoo.stpl
@@ -44,8 +44,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
     
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -54,7 +54,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/odoo.tpl
@@ -40,8 +40,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/opencart.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/opencart.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -38,8 +38,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -48,7 +48,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/opencart.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/opencart.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/owncloud.stpl
@@ -27,7 +27,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -59,8 +59,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -69,7 +69,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/owncloud.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/owncloud.tpl
@@ -23,7 +23,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -55,8 +55,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -65,7 +65,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/piwik.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/piwik.stpl
@@ -29,7 +29,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,18 +37,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-        return 404; 
+        return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
         }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -57,7 +57,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/piwik.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/piwik.tpl
@@ -25,7 +25,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,18 +33,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-            return 404; 
+            return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -25,7 +25,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -40,8 +40,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/pyrocms.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/pyrocms.tpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -36,8 +36,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -46,7 +46,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/sendy.stpl
@@ -40,7 +40,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -67,8 +67,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/sendy.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/sendy.tpl
@@ -38,7 +38,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -65,8 +65,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -28,7 +28,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -37,7 +37,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/cms_made_simple.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/cms_made_simple.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/codeigniter2.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/codeigniter2.stpl
@@ -21,7 +21,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -35,8 +35,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -45,7 +45,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/codeigniter2.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/codeigniter2.tpl
@@ -17,7 +17,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -31,8 +31,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -41,7 +41,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/codeigniter3.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/codeigniter3.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/codeigniter3.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/codeigniter3.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -92,7 +92,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -101,8 +101,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -111,7 +111,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/datalife_engine.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/datalife_engine.tpl
@@ -88,7 +88,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -97,8 +97,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -107,7 +107,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/default.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/default.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/default.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/default.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -22,7 +22,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/dokuwiki.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/dokuwiki.tpl
@@ -18,7 +18,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/drupal6.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/drupal6.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/drupal6.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/drupal6.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/drupal7.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/drupal7.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/drupal7.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/drupal7.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/drupal8.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/drupal8.stpl
@@ -54,7 +54,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -76,8 +76,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -86,7 +86,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/drupal8.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/drupal8.tpl
@@ -51,7 +51,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -73,8 +73,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -83,7 +83,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/joomla.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/joomla.stpl
@@ -27,7 +27,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/joomla.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/joomla.tpl
@@ -23,7 +23,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/laravel.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/laravel.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/laravel.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -24,8 +24,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -34,7 +34,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/magento.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/magento.stpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     ssl         on;
@@ -146,8 +146,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/magento.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/magento.tpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     access_log  /var/log/nginx/domains/%domain%.log combined;
@@ -142,8 +142,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/modx.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/modx.stpl
@@ -36,15 +36,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/modx.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/modx.tpl
@@ -32,15 +32,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -49,7 +49,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/moodle.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -64,8 +64,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -74,7 +74,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/moodle.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/moodle.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -61,8 +61,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -71,7 +71,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/no-php.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/no-php.stpl
@@ -21,8 +21,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -31,7 +31,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/no-php.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/no-php.tpl
@@ -17,8 +17,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -27,7 +27,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/odoo.stpl
@@ -44,8 +44,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
     
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -54,7 +54,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/odoo.tpl
@@ -40,8 +40,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/opencart.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/opencart.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -38,8 +38,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -48,7 +48,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/opencart.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/opencart.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/owncloud.stpl
@@ -27,7 +27,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -59,8 +59,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -69,7 +69,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/owncloud.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/owncloud.tpl
@@ -23,7 +23,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -55,8 +55,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -65,7 +65,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/piwik.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/piwik.stpl
@@ -29,7 +29,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,18 +37,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-        return 404; 
+        return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
         }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -57,7 +57,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/piwik.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/piwik.tpl
@@ -25,7 +25,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,18 +33,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-            return 404; 
+            return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -25,7 +25,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -40,8 +40,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/pyrocms.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/pyrocms.tpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -36,8 +36,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -46,7 +46,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/sendy.stpl
@@ -40,7 +40,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -67,8 +67,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/sendy.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/sendy.tpl
@@ -38,7 +38,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -65,8 +65,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -28,7 +28,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -37,7 +37,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/cms_made_simple.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/cms_made_simple.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/codeigniter2.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/codeigniter2.stpl
@@ -21,7 +21,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -35,8 +35,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -45,7 +45,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/codeigniter2.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/codeigniter2.tpl
@@ -17,7 +17,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -31,8 +31,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -41,7 +41,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/codeigniter3.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/codeigniter3.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/codeigniter3.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/codeigniter3.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -92,7 +92,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -101,8 +101,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -111,7 +111,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/datalife_engine.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/datalife_engine.tpl
@@ -88,7 +88,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -97,8 +97,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -107,7 +107,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/default.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/default.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/default.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/default.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -22,7 +22,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/dokuwiki.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/dokuwiki.tpl
@@ -18,7 +18,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/drupal6.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/drupal6.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/drupal6.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/drupal6.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/drupal7.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/drupal7.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/drupal7.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/drupal7.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/drupal8.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/drupal8.stpl
@@ -54,7 +54,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -76,8 +76,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -86,7 +86,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/drupal8.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/drupal8.tpl
@@ -51,7 +51,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -73,8 +73,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -83,7 +83,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/joomla.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/joomla.stpl
@@ -27,7 +27,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/joomla.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/joomla.tpl
@@ -23,7 +23,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/laravel.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/laravel.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/laravel.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -24,8 +24,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -34,7 +34,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/magento.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/magento.stpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     ssl         on;
@@ -146,8 +146,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/magento.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/magento.tpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     access_log  /var/log/nginx/domains/%domain%.log combined;
@@ -142,8 +142,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/modx.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/modx.stpl
@@ -36,15 +36,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/modx.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/modx.tpl
@@ -32,15 +32,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -49,7 +49,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/moodle.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -64,8 +64,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -74,7 +74,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/moodle.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/moodle.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -61,8 +61,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -71,7 +71,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/no-php.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/no-php.stpl
@@ -21,8 +21,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -31,7 +31,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/no-php.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/no-php.tpl
@@ -17,8 +17,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -27,7 +27,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/odoo.stpl
@@ -44,8 +44,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
     
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -54,7 +54,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/odoo.tpl
@@ -40,8 +40,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/opencart.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/opencart.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -38,8 +38,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -48,7 +48,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/opencart.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/opencart.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/owncloud.stpl
@@ -27,7 +27,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -59,8 +59,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -69,7 +69,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/owncloud.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/owncloud.tpl
@@ -23,7 +23,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -55,8 +55,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -65,7 +65,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/piwik.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/piwik.stpl
@@ -29,7 +29,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,18 +37,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-        return 404; 
+        return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
         }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -57,7 +57,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/piwik.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/piwik.tpl
@@ -25,7 +25,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,18 +33,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-            return 404; 
+            return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -25,7 +25,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -40,8 +40,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/pyrocms.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/pyrocms.tpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -36,8 +36,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -46,7 +46,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/sendy.stpl
@@ -40,7 +40,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -67,8 +67,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/sendy.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/sendy.tpl
@@ -38,7 +38,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -65,8 +65,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -28,7 +28,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -37,7 +37,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/cms_made_simple.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/cms_made_simple.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/codeigniter2.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/codeigniter2.stpl
@@ -21,7 +21,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -35,8 +35,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -45,7 +45,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/codeigniter2.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/codeigniter2.tpl
@@ -17,7 +17,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -31,8 +31,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -41,7 +41,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/codeigniter3.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/codeigniter3.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/codeigniter3.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/codeigniter3.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -92,7 +92,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -101,8 +101,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -111,7 +111,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/datalife_engine.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/datalife_engine.tpl
@@ -88,7 +88,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -97,8 +97,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -107,7 +107,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/default.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/default.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/default.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/default.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -22,7 +22,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/dokuwiki.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/dokuwiki.tpl
@@ -18,7 +18,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/drupal6.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/drupal6.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/drupal6.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/drupal6.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/drupal7.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/drupal7.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/drupal7.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/drupal7.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/drupal8.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/drupal8.stpl
@@ -54,7 +54,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -76,8 +76,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -86,7 +86,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/drupal8.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/drupal8.tpl
@@ -51,7 +51,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -73,8 +73,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -83,7 +83,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/joomla.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/joomla.stpl
@@ -27,7 +27,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/joomla.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/joomla.tpl
@@ -23,7 +23,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/laravel.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/laravel.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/laravel.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -24,8 +24,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -34,7 +34,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/magento.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/magento.stpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     ssl         on;
@@ -146,8 +146,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/magento.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/magento.tpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     access_log  /var/log/nginx/domains/%domain%.log combined;
@@ -142,8 +142,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/modx.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/modx.stpl
@@ -36,15 +36,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/modx.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/modx.tpl
@@ -32,15 +32,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -49,7 +49,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/moodle.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -64,8 +64,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -74,7 +74,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/moodle.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/moodle.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -61,8 +61,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -71,7 +71,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/no-php.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/no-php.stpl
@@ -21,8 +21,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -31,7 +31,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/no-php.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/no-php.tpl
@@ -17,8 +17,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -27,7 +27,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/odoo.stpl
@@ -44,8 +44,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
     
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -54,7 +54,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/odoo.tpl
@@ -40,8 +40,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/opencart.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/opencart.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -38,8 +38,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -48,7 +48,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/opencart.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/opencart.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/owncloud.stpl
@@ -27,7 +27,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -59,8 +59,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -69,7 +69,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/owncloud.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/owncloud.tpl
@@ -23,7 +23,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -55,8 +55,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -65,7 +65,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/piwik.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/piwik.stpl
@@ -29,7 +29,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,18 +37,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-        return 404; 
+        return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
         }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -57,7 +57,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/piwik.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/piwik.tpl
@@ -25,7 +25,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,18 +33,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-            return 404; 
+            return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -25,7 +25,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -40,8 +40,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/pyrocms.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/pyrocms.tpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -36,8 +36,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -46,7 +46,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/sendy.stpl
@@ -40,7 +40,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -67,8 +67,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/sendy.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/sendy.tpl
@@ -38,7 +38,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -65,8 +65,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -28,7 +28,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -37,7 +37,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/cms_made_simple.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/cms_made_simple.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/codeigniter2.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/codeigniter2.stpl
@@ -21,7 +21,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -35,8 +35,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -45,7 +45,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/codeigniter2.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/codeigniter2.tpl
@@ -17,7 +17,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -31,8 +31,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -41,7 +41,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/codeigniter3.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/codeigniter3.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/codeigniter3.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/codeigniter3.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -92,7 +92,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -101,8 +101,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -111,7 +111,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/datalife_engine.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/datalife_engine.tpl
@@ -88,7 +88,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -97,8 +97,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -107,7 +107,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/default.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/default.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/default.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/default.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -22,7 +22,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/dokuwiki.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/dokuwiki.tpl
@@ -18,7 +18,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/drupal6.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/drupal6.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/drupal6.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/drupal6.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/drupal7.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/drupal7.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/drupal7.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/drupal7.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/drupal8.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/drupal8.stpl
@@ -54,7 +54,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -76,8 +76,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -86,7 +86,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/drupal8.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/drupal8.tpl
@@ -51,7 +51,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -73,8 +73,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -83,7 +83,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/joomla.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/joomla.stpl
@@ -27,7 +27,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/joomla.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/joomla.tpl
@@ -23,7 +23,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/laravel.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/laravel.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/laravel.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -24,8 +24,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -34,7 +34,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/magento.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/magento.stpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     ssl         on;
@@ -146,8 +146,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/magento.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/magento.tpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     access_log  /var/log/nginx/domains/%domain%.log combined;
@@ -142,8 +142,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/modx.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/modx.stpl
@@ -36,15 +36,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/modx.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/modx.tpl
@@ -32,15 +32,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -49,7 +49,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/moodle.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -64,8 +64,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -74,7 +74,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/moodle.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/moodle.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -61,8 +61,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -71,7 +71,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/no-php.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/no-php.stpl
@@ -21,8 +21,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -31,7 +31,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/no-php.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/no-php.tpl
@@ -17,8 +17,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -27,7 +27,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/odoo.stpl
@@ -44,8 +44,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
     
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -54,7 +54,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/odoo.tpl
@@ -40,8 +40,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/opencart.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/opencart.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -38,8 +38,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -48,7 +48,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/opencart.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/opencart.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/owncloud.stpl
@@ -27,7 +27,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -59,8 +59,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -69,7 +69,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/owncloud.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/owncloud.tpl
@@ -23,7 +23,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -55,8 +55,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -65,7 +65,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/piwik.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/piwik.stpl
@@ -29,7 +29,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,18 +37,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-        return 404; 
+        return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
         }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -57,7 +57,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/piwik.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/piwik.tpl
@@ -25,7 +25,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,18 +33,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-            return 404; 
+            return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -25,7 +25,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -40,8 +40,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/pyrocms.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/pyrocms.tpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -36,8 +36,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -46,7 +46,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/sendy.stpl
@@ -40,7 +40,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -67,8 +67,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/sendy.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/sendy.tpl
@@ -38,7 +38,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -65,8 +65,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -28,7 +28,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -37,7 +37,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/cms_made_simple.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/cms_made_simple.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/codeigniter2.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/codeigniter2.stpl
@@ -21,7 +21,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -35,8 +35,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -45,7 +45,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/codeigniter2.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/codeigniter2.tpl
@@ -17,7 +17,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -31,8 +31,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -41,7 +41,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/codeigniter3.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/codeigniter3.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/codeigniter3.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/codeigniter3.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -92,7 +92,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -101,8 +101,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -111,7 +111,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/datalife_engine.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/datalife_engine.tpl
@@ -88,7 +88,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -97,8 +97,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -107,7 +107,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/default.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/default.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/default.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/default.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -22,7 +22,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/dokuwiki.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/dokuwiki.tpl
@@ -18,7 +18,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/drupal6.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/drupal6.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/drupal6.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/drupal6.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/drupal7.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/drupal7.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/drupal7.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/drupal7.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/drupal8.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/drupal8.stpl
@@ -54,7 +54,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -76,8 +76,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -86,7 +86,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/drupal8.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/drupal8.tpl
@@ -51,7 +51,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -73,8 +73,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -83,7 +83,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/joomla.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/joomla.stpl
@@ -27,7 +27,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/joomla.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/joomla.tpl
@@ -23,7 +23,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/laravel.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/laravel.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/laravel.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -24,8 +24,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -34,7 +34,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/magento.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/magento.stpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     ssl         on;
@@ -146,8 +146,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/magento.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/magento.tpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     access_log  /var/log/nginx/domains/%domain%.log combined;
@@ -142,8 +142,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/modx.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/modx.stpl
@@ -36,15 +36,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/modx.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/modx.tpl
@@ -32,15 +32,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -49,7 +49,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/moodle.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -64,8 +64,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -74,7 +74,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/moodle.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/moodle.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -61,8 +61,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -71,7 +71,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/no-php.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/no-php.stpl
@@ -21,8 +21,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -31,7 +31,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/no-php.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/no-php.tpl
@@ -17,8 +17,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -27,7 +27,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/odoo.stpl
@@ -44,8 +44,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
     
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -54,7 +54,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/odoo.tpl
@@ -40,8 +40,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/opencart.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/opencart.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -38,8 +38,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -48,7 +48,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/opencart.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/opencart.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/owncloud.stpl
@@ -27,7 +27,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -59,8 +59,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -69,7 +69,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/owncloud.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/owncloud.tpl
@@ -23,7 +23,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -55,8 +55,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -65,7 +65,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/piwik.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/piwik.stpl
@@ -29,7 +29,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,18 +37,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-        return 404; 
+        return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
         }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -57,7 +57,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/piwik.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/piwik.tpl
@@ -25,7 +25,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,18 +33,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-            return 404; 
+            return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -25,7 +25,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -40,8 +40,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/pyrocms.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/pyrocms.tpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -36,8 +36,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -46,7 +46,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/sendy.stpl
@@ -40,7 +40,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -67,8 +67,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/sendy.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/sendy.tpl
@@ -38,7 +38,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -65,8 +65,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -28,7 +28,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -37,7 +37,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/cms_made_simple.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/cms_made_simple.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
             fastcgi_pass    %backend_lsnr%;
             fastcgi_index   index.php;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/codeigniter2.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/codeigniter2.stpl
@@ -21,7 +21,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -35,8 +35,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -45,7 +45,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/codeigniter2.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/codeigniter2.tpl
@@ -17,7 +17,7 @@ server {
         location = /index.php {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -31,8 +31,8 @@ server {
         return 444;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -41,7 +41,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/codeigniter3.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/codeigniter3.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/codeigniter3.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/codeigniter3.tpl
@@ -17,7 +17,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -26,8 +26,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -36,7 +36,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -92,7 +92,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -101,8 +101,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -111,7 +111,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/datalife_engine.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/datalife_engine.tpl
@@ -88,7 +88,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -97,8 +97,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -107,7 +107,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/default.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/default.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/default.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/default.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -22,7 +22,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/dokuwiki.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/dokuwiki.tpl
@@ -18,7 +18,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         rewrite ^/(.*) /doku.php?id=$1 last;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/drupal6.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/drupal6.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/drupal6.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/drupal6.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/drupal7.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/drupal7.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -75,8 +75,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -85,7 +85,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/drupal7.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/drupal7.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -72,8 +72,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -82,7 +82,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/drupal8.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/drupal8.stpl
@@ -54,7 +54,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -76,8 +76,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -86,7 +86,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/drupal8.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/drupal8.tpl
@@ -51,7 +51,7 @@ server {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -73,8 +73,8 @@ server {
         try_files $uri @rewrite;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -83,7 +83,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/joomla.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/joomla.stpl
@@ -27,7 +27,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/joomla.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/joomla.tpl
@@ -23,7 +23,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/laravel.stpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -30,8 +30,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -40,7 +40,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/laravel.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/laravel.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -24,8 +24,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -34,7 +34,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/magento.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/magento.stpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     ssl         on;
@@ -146,8 +146,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/magento.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/magento.tpl
@@ -6,7 +6,7 @@ server {
     index       index.php;
     autoindex   off;
     charset     UTF-8;
-    error_page  404 403 = /errors/404.php;
+    error_page  403 403 = /errors/403.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
     access_log  /var/log/nginx/domains/%domain%.log combined;
@@ -142,8 +142,8 @@ server {
     }
 
     # PHP entry point for main application
-    location ~ (index|get|static|report|404|503)\.php$ {
-        try_files $uri =404;
+    location ~ (index|get|static|report|403|503)\.php$ {
+        try_files $uri =403;
 
         fastcgi_pass   %backend_lsnr%;
         fastcgi_buffers 1024 4k;

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/modx.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/modx.stpl
@@ -36,15 +36,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/modx.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/modx.tpl
@@ -32,15 +32,15 @@ server {
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files $uri =403;
         fastcgi_pass %backend_lsnr%;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         include /etc/nginx/fastcgi_params;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -49,7 +49,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/moodle.stpl
@@ -53,7 +53,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -64,8 +64,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -74,7 +74,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/moodle.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/moodle.tpl
@@ -50,7 +50,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -61,8 +61,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -71,7 +71,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/no-php.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/no-php.stpl
@@ -21,8 +21,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -31,7 +31,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/no-php.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/no-php.tpl
@@ -17,8 +17,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -27,7 +27,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/odoo.stpl
@@ -44,8 +44,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
     
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -54,7 +54,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/odoo.tpl
@@ -40,8 +40,8 @@ server {
         proxy_pass http://127.0.0.1:8069;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/opencart.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/opencart.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -38,8 +38,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -48,7 +48,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/opencart.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/opencart.tpl
@@ -15,7 +15,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,8 +33,8 @@ server {
         include %home%/%user%/conf/web/%domain%.auth*;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -43,7 +43,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     include     /etc/nginx/conf.d/phpmyadmin.inc*;

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/owncloud.stpl
@@ -27,7 +27,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -59,8 +59,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -69,7 +69,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/owncloud.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/owncloud.tpl
@@ -23,7 +23,7 @@ server {
     rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
 
     error_page 403 = /core/templates/403.php;
-    error_page 404 = /core/templates/404.php;
+    error_page 403 = /core/templates/403.php;
 
     location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
         deny all;
@@ -55,8 +55,8 @@ server {
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
     }
 
-    #error_page  403 /error/404.html;
-    #error_page  404 /error/404.html;
+    #error_page  403 /error/403.html;
+    #error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -65,7 +65,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/piwik.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/piwik.stpl
@@ -29,7 +29,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,18 +37,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-        return 404; 
+        return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
         }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -57,7 +57,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/piwik.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/piwik.tpl
@@ -25,7 +25,7 @@ server {
         location ~* ^/(?:index|piwik)\.php$ {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return 404;
+                return 403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -33,18 +33,18 @@ server {
         }
     }
 
-    # Any other attempt to access PHP files returns a 404.
+    # Any other attempt to access PHP files returns a 403.
     location ~* ^.+\.php$ {
-            return 404; 
+            return 403; 
     }
 
-    # Return a 404 for all text files.
+    # Return a 403 for all text files.
     location ~* ^/(?:README|LICENSE[^.]*|LEGALNOTICE)(?:\.txt)*$ {
-            return 404;
+            return 403;
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -53,7 +53,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -25,7 +25,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -40,8 +40,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -50,7 +50,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/pyrocms.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/pyrocms.tpl
@@ -21,7 +21,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -36,8 +36,8 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
     location ~ ~$           { access_log off; log_not_found off; deny all; }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -46,7 +46,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/sendy.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/sendy.stpl
@@ -40,7 +40,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -67,8 +67,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/sendy.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/sendy.tpl
@@ -38,7 +38,7 @@ server {
 
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            try_files $uri =404;
+            try_files $uri =403;
             fastcgi_pass %backend_lsnr%;
             fastcgi_index index.php;
             include /etc/nginx/fastcgi_params;
@@ -65,8 +65,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress.stpl
@@ -20,7 +20,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -29,8 +29,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -39,7 +39,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress.tpl
@@ -16,7 +16,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -25,8 +25,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -35,7 +35,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress2.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress2.tpl
@@ -28,7 +28,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -37,8 +37,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -47,7 +47,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -37,7 +37,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -46,8 +46,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -56,7 +56,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress2_rewrite.tpl
@@ -32,7 +32,7 @@ server {
         location ~ [^/]\.php(/|$) {
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             if (!-f $document_root$fastcgi_script_name) {
-                return  404;
+                return  403;
             }
 
             fastcgi_pass    %backend_lsnr%;
@@ -41,8 +41,8 @@ server {
         }
     }
 
-    error_page  403 /error/404.html;
-    error_page  404 /error/404.html;
+    error_page  403 /error/403.html;
+    error_page  403 /error/403.html;
     error_page  500 502 503 504 /error/50x.html;
 
     location /error/ {
@@ -51,7 +51,7 @@ server {
 
     location ~* "/\.(htaccess|htpasswd)$" {
         deny    all;
-        return  404;
+        return  403;
     }
 
     location /vstats/ {


### PR DESCRIPTION
Makes "SSL Certificate Authority / Intermediate (optional)" textbox work as expected, optional.
Without this commit, it's not possible to add SSL certificates without SSL Chain (.pem). Some providers like CloudFlare won't give SSL Chain file, and therefore it's not possible to use CloudFlare SSL.

By removing the necessary validation, we can use SSL without CA.