### PR TITLE
Fix add www. as alias

### DIFF
--- a/func/main.sh
+++ b/func/main.sh
@@ -906,7 +906,7 @@ format_aliases() {
         aliases=$(echo "$aliases" |tr -s '.')
         aliases=$(echo "$aliases" |sed -e "s/[.]*$//g")
         aliases=$(echo "$aliases" |sed -e "s/^[.]*//")
-        aliases=$(echo "$aliases" |grep -v www.$domain |sed -e "/^$/d")
+        aliases=$(echo "$aliases" |sed -e "/^$/d")
         aliases=$(echo "$aliases" |tr '\n' ',' |sed -e "s/,$//")
     fi
 }


### PR DESCRIPTION
Sinds https://github.com/serghey-rodin/vesta/commit/e5950d516d52fe4776c6527676d0823780a7f8d7 it is not possible to add www.yourdomain.com as alias to the web domain yourdomain.com 

Bug: #1489
Previous fix but reverted: https://github.com/serghey-rodin/vesta/commit/74fa6d5b0ce78cbb85ea657d16f8f2c3dba93c6c