### PR TITLE
Backported changes from the default exim config

### DIFF
--- a/install/debian/7/exim/exim4.conf.template
+++ b/install/debian/7/exim/exim4.conf.template
@@ -11,7 +11,7 @@
 disable_ipv6=true
 domainlist local_domains = dsearch;/etc/exim4/domains/
 domainlist relay_to_domains = dsearch;/etc/exim4/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim4/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim4/spam-blocks.conf
 no_local_from_check
@@ -38,8 +38,6 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
 
@@ -204,6 +202,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:

--- a/install/debian/8/exim/exim4.conf.template
+++ b/install/debian/8/exim/exim4.conf.template
@@ -9,12 +9,10 @@
 #CLAMD =  yes
 
 disable_ipv6=true
-add_environment=<; PATH=/bin:/usr/bin
-keep_environment=
 
 domainlist local_domains = dsearch;/etc/exim4/domains/
 domainlist relay_to_domains = dsearch;/etc/exim4/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim4/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim4/spam-blocks.conf
 no_local_from_check
@@ -41,10 +39,11 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
+prdr_enable = true
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
+keep_environment = ^LDAP
+add_environment = PATH=/usr/bin::/bin
 
 DKIM_DOMAIN = ${lc:${domain:$h_from:}}
 DKIM_FILE = /etc/exim4/domains/${lc:${domain:$h_from:}}/dkim.pem
@@ -207,6 +206,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:

--- a/install/debian/9/exim/exim4.conf.template
+++ b/install/debian/9/exim/exim4.conf.template
@@ -9,12 +9,10 @@
 #CLAMD =  yes
 
 disable_ipv6=true
-add_environment=<; PATH=/bin:/usr/bin
-keep_environment=
 
 domainlist local_domains = dsearch;/etc/exim4/domains/
 domainlist relay_to_domains = dsearch;/etc/exim4/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim4/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim4/spam-blocks.conf
 no_local_from_check
@@ -41,10 +39,11 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
+prdr_enable = true
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
+keep_environment = ^LDAP
+add_environment = PATH=/usr/bin::/bin
 
 DKIM_DOMAIN = ${lc:${domain:$h_from:}}
 DKIM_FILE = /etc/exim4/domains/${lc:${domain:$h_from:}}/dkim.pem
@@ -207,6 +206,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:

--- a/install/rhel/5/exim/exim-smarthost.conf
+++ b/install/rhel/5/exim/exim-smarthost.conf
@@ -10,7 +10,7 @@
 
 domainlist local_domains = dsearch;/etc/exim/domains/
 domainlist relay_to_domains = dsearch;/etc/exim/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim/spam-blocks.conf
 no_local_from_check
@@ -37,8 +37,6 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
 
@@ -206,6 +204,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:

--- a/install/rhel/5/exim/exim.conf
+++ b/install/rhel/5/exim/exim.conf
@@ -10,7 +10,7 @@
 
 domainlist local_domains = dsearch;/etc/exim/domains/
 domainlist relay_to_domains = dsearch;/etc/exim/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim/spam-blocks.conf
 no_local_from_check
@@ -37,8 +37,6 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
 
@@ -203,6 +201,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:

--- a/install/rhel/6/exim/exim-smarthost.conf
+++ b/install/rhel/6/exim/exim-smarthost.conf
@@ -10,7 +10,7 @@
 
 domainlist local_domains = dsearch;/etc/exim/domains/
 domainlist relay_to_domains = dsearch;/etc/exim/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim/spam-blocks.conf
 no_local_from_check
@@ -37,10 +37,11 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
+prdr_enable = true
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
+keep_environment = ^LDAP
+add_environment = PATH=/usr/bin::/bin
 
 DKIM_DOMAIN = ${lc:${domain:$h_from:}}
 DKIM_FILE = /etc/exim/domains/${lc:${domain:$h_from:}}/dkim.pem
@@ -206,6 +207,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:

--- a/install/rhel/6/exim/exim.conf
+++ b/install/rhel/6/exim/exim.conf
@@ -11,7 +11,7 @@
 disable_ipv6=true
 domainlist local_domains = dsearch;/etc/exim/domains/
 domainlist relay_to_domains = dsearch;/etc/exim/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim/spam-blocks.conf
 no_local_from_check
@@ -38,10 +38,11 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
+prdr_enable = true
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
+keep_environment = ^LDAP
+add_environment = PATH=/usr/bin::/bin
 
 DKIM_DOMAIN = ${lc:${domain:$h_from:}}
 DKIM_FILE = /etc/exim/domains/${lc:${domain:$h_from:}}/dkim.pem
@@ -204,6 +205,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:

--- a/install/rhel/7/exim/exim-smarthost.conf
+++ b/install/rhel/7/exim/exim-smarthost.conf
@@ -10,7 +10,7 @@
 
 domainlist local_domains = dsearch;/etc/exim/domains/
 domainlist relay_to_domains = dsearch;/etc/exim/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim/spam-blocks.conf
 no_local_from_check
@@ -37,10 +37,11 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
+prdr_enable = true
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
+keep_environment = ^LDAP
+add_environment = PATH=/usr/bin::/bin
 
 DKIM_DOMAIN = ${lc:${domain:$h_from:}}
 DKIM_FILE = /etc/exim/domains/${lc:${domain:$h_from:}}/dkim.pem
@@ -206,6 +207,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:

--- a/install/rhel/7/exim/exim.conf
+++ b/install/rhel/7/exim/exim.conf
@@ -13,7 +13,7 @@ keep_environment =
 disable_ipv6=true
 domainlist local_domains = dsearch;/etc/exim/domains/
 domainlist relay_to_domains = dsearch;/etc/exim/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim/spam-blocks.conf
 no_local_from_check
@@ -40,10 +40,11 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
+prdr_enable = true
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
+keep_environment = ^LDAP
+add_environment = PATH=/usr/bin::/bin
 
 DKIM_DOMAIN = ${lc:${domain:$h_from:}}
 DKIM_FILE = /etc/exim/domains/${lc:${domain:$h_from:}}/dkim.pem
@@ -206,6 +207,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:

--- a/install/ubuntu/12.04/exim/exim4.conf.template
+++ b/install/ubuntu/12.04/exim/exim4.conf.template
@@ -8,13 +8,11 @@
 #SPAM_SCORE = 50
 #CLAMD =  yes
 
-add_environment = <; PATH=/bin:/usr/bin
-keep_environment =
 disable_ipv6 = true
 
 domainlist local_domains = dsearch;/etc/exim4/domains/
 domainlist relay_to_domains = dsearch;/etc/exim4/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim4/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim4/spam-blocks.conf
 no_local_from_check
@@ -41,10 +39,10 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
+keep_environment = ^LDAP
+add_environment = PATH=/usr/bin::/bin
 
 DKIM_DOMAIN = ${lc:${domain:$h_from:}}
 DKIM_FILE = /etc/exim4/domains/${lc:${domain:$h_from:}}/dkim.pem
@@ -207,6 +205,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:

--- a/install/ubuntu/12.10/exim/exim4.conf.template
+++ b/install/ubuntu/12.10/exim/exim4.conf.template
@@ -8,13 +8,11 @@
 #SPAM_SCORE = 50
 #CLAMD =  yes
 
-add_environment = <; PATH=/bin:/usr/bin
-keep_environment =
 disable_ipv6 = true
 
 domainlist local_domains = dsearch;/etc/exim4/domains/
 domainlist relay_to_domains = dsearch;/etc/exim4/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim4/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim4/spam-blocks.conf
 no_local_from_check
@@ -41,10 +39,10 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
+keep_environment = ^LDAP
+add_environment = PATH=/usr/bin::/bin
 
 DKIM_DOMAIN = ${lc:${domain:$h_from:}}
 DKIM_FILE = /etc/exim4/domains/${lc:${domain:$h_from:}}/dkim.pem
@@ -207,6 +205,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:

--- a/install/ubuntu/13.04/exim/exim4.conf.template
+++ b/install/ubuntu/13.04/exim/exim4.conf.template
@@ -8,13 +8,11 @@
 #SPAM_SCORE = 50
 #CLAMD =  yes
 
-add_environment = <; PATH=/bin:/usr/bin
-keep_environment =
 disable_ipv6 = true
 
 domainlist local_domains = dsearch;/etc/exim4/domains/
 domainlist relay_to_domains = dsearch;/etc/exim4/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim4/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim4/spam-blocks.conf
 no_local_from_check
@@ -41,10 +39,10 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
+keep_environment = ^LDAP
+add_environment = PATH=/usr/bin::/bin
 
 DKIM_DOMAIN = ${lc:${domain:$h_from:}}
 DKIM_FILE = /etc/exim4/domains/${lc:${domain:$h_from:}}/dkim.pem
@@ -207,6 +205,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:

--- a/install/ubuntu/13.10/exim/exim4.conf.template
+++ b/install/ubuntu/13.10/exim/exim4.conf.template
@@ -8,13 +8,11 @@
 #SPAM_SCORE = 50
 #CLAMD =  yes
 
-add_environment = <; PATH=/bin:/usr/bin
-keep_environment =
 disable_ipv6 = true
 
 domainlist local_domains = dsearch;/etc/exim4/domains/
 domainlist relay_to_domains = dsearch;/etc/exim4/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim4/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim4/spam-blocks.conf
 no_local_from_check
@@ -41,10 +39,10 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
+keep_environment = ^LDAP
+add_environment = PATH=/usr/bin::/bin
 
 DKIM_DOMAIN = ${lc:${domain:$h_from:}}
 DKIM_FILE = /etc/exim4/domains/${lc:${domain:$h_from:}}/dkim.pem
@@ -207,6 +205,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:

--- a/install/ubuntu/14.04/exim/exim4.conf.template
+++ b/install/ubuntu/14.04/exim/exim4.conf.template
@@ -8,13 +8,11 @@
 #SPAM_SCORE = 50
 #CLAMD =  yes
 
-add_environment = <; PATH=/bin:/usr/bin
-keep_environment =
 disable_ipv6 = true
 
 domainlist local_domains = dsearch;/etc/exim4/domains/
 domainlist relay_to_domains = dsearch;/etc/exim4/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim4/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim4/spam-blocks.conf
 no_local_from_check
@@ -41,10 +39,11 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
+prdr_enable = true
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
+keep_environment = ^LDAP
+add_environment = PATH=/usr/bin::/bin
 
 DKIM_DOMAIN = ${lc:${domain:$h_from:}}
 DKIM_FILE = /etc/exim4/domains/${lc:${domain:$h_from:}}/dkim.pem
@@ -207,6 +206,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:

--- a/install/ubuntu/14.10/exim/exim4.conf.template
+++ b/install/ubuntu/14.10/exim/exim4.conf.template
@@ -8,13 +8,11 @@
 #SPAM_SCORE = 50
 #CLAMD =  yes
 
-add_environment = <; PATH=/bin:/usr/bin
-keep_environment =
 disable_ipv6 = true
 
 domainlist local_domains = dsearch;/etc/exim4/domains/
 domainlist relay_to_domains = dsearch;/etc/exim4/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim4/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim4/spam-blocks.conf
 no_local_from_check
@@ -41,10 +39,11 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
+prdr_enable = true
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
+keep_environment = ^LDAP
+add_environment = PATH=/usr/bin::/bin
 
 DKIM_DOMAIN = ${lc:${domain:$h_from:}}
 DKIM_FILE = /etc/exim4/domains/${lc:${domain:$h_from:}}/dkim.pem
@@ -207,6 +206,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:

--- a/install/ubuntu/15.04/exim/exim4.conf.template
+++ b/install/ubuntu/15.04/exim/exim4.conf.template
@@ -8,13 +8,11 @@
 #SPAM_SCORE = 50
 #CLAMD =  yes
 
-add_environment = <; PATH=/bin:/usr/bin
-keep_environment =
 disable_ipv6 = true
 
 domainlist local_domains = dsearch;/etc/exim4/domains/
 domainlist relay_to_domains = dsearch;/etc/exim4/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim4/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim4/spam-blocks.conf
 no_local_from_check
@@ -41,10 +39,11 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
+prdr_enable = true
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
+keep_environment = ^LDAP
+add_environment = PATH=/usr/bin::/bin
 
 DKIM_DOMAIN = ${lc:${domain:$h_from:}}
 DKIM_FILE = /etc/exim4/domains/${lc:${domain:$h_from:}}/dkim.pem
@@ -207,6 +206,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:

--- a/install/ubuntu/15.10/exim/exim4.conf.template
+++ b/install/ubuntu/15.10/exim/exim4.conf.template
@@ -8,13 +8,11 @@
 #SPAM_SCORE = 50
 #CLAMD =  yes
 
-add_environment = <; PATH=/bin:/usr/bin
-keep_environment =
 disable_ipv6 = true
 
 domainlist local_domains = dsearch;/etc/exim4/domains/
 domainlist relay_to_domains = dsearch;/etc/exim4/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim4/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim4/spam-blocks.conf
 no_local_from_check
@@ -41,10 +39,11 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
+prdr_enable = true
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
+keep_environment = ^LDAP
+add_environment = PATH=/usr/bin::/bin
 
 DKIM_DOMAIN = ${lc:${domain:$h_from:}}
 DKIM_FILE = /etc/exim4/domains/${lc:${domain:$h_from:}}/dkim.pem
@@ -207,6 +206,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:

--- a/install/ubuntu/16.04/exim/exim4.conf.template
+++ b/install/ubuntu/16.04/exim/exim4.conf.template
@@ -8,13 +8,11 @@
 #SPAM_SCORE = 50
 #CLAMD =  yes
 
-add_environment = <; PATH=/bin:/usr/bin
-keep_environment =
 disable_ipv6 = true
 
 domainlist local_domains = dsearch;/etc/exim4/domains/
 domainlist relay_to_domains = dsearch;/etc/exim4/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim4/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim4/spam-blocks.conf
 no_local_from_check
@@ -41,10 +39,11 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
+prdr_enable = true
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
+keep_environment = ^LDAP
+add_environment = PATH=/usr/bin::/bin
 
 DKIM_DOMAIN = ${lc:${domain:$h_from:}}
 DKIM_FILE = /etc/exim4/domains/${lc:${domain:$h_from:}}/dkim.pem
@@ -207,6 +206,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:

--- a/install/ubuntu/16.10/exim/exim4.conf.template
+++ b/install/ubuntu/16.10/exim/exim4.conf.template
@@ -8,13 +8,11 @@
 #SPAM_SCORE = 50
 #CLAMD =  yes
 
-add_environment = <; PATH=/bin:/usr/bin
-keep_environment =
 disable_ipv6 = true
 
 domainlist local_domains = dsearch;/etc/exim4/domains/
 domainlist relay_to_domains = dsearch;/etc/exim4/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = localhost
 hostlist whitelist = net-iplsearch;/etc/exim4/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim4/spam-blocks.conf
 no_local_from_check
@@ -41,10 +39,11 @@ daemon_smtp_ports = 25 : 465 : 587 : 2525
 tls_on_connect_ports = 465
 never_users = root
 host_lookup = *
-rfc1413_hosts = *
-rfc1413_query_timeout = 5s
+prdr_enable = true
 ignore_bounce_errors_after = 2d
 timeout_frozen_after = 7d
+keep_environment = ^LDAP
+add_environment = PATH=/usr/bin::/bin
 
 DKIM_DOMAIN = ${lc:${domain:$h_from:}}
 DKIM_FILE = /etc/exim4/domains/${lc:${domain:$h_from:}}/dkim.pem
@@ -207,6 +206,7 @@ dnslookup:
   driver = dnslookup
   domains = !+local_domains
   transport = remote_smtp
+  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
   no_more
 
 userforward:


### PR DESCRIPTION
Changes:

`hostlist relay_from_hosts = localhost`
instead of
`hostlist relay_from_hosts = 127.0.0.1`
because of
https://github.com/Exim/exim/commit/ff284120aa17a2b2d16d13bcdf67b794800f047c
https://github.com/Exim/exim/pull/1/files

Removed
```
rfc1413_hosts = *
rfc1413_query_timeout = 5s
```
because of
https://github.com/Exim/exim/commit/f926e27276301de1e2fd011b7edcd1b85d8c4754#diff-3489bb4734f2a6f27caffbaedb4bd782

Added (to modern OS)
`prdr_enable = true`
because of
https://github.com/Exim/exim/commit/ff1c79bc224878d274eebc592750e525d1a98f9b
https://www.exim.org/exim-html-current/doc/html/spec_html/ch-access_control_lists.html#SECTPRDRACL

Removed from this PR, see comments
```
acl_check_data:
  deny   message        = maximum allowed line length is 998 octets, \
                          got $max_received_linelength
         condition      = ${if > {$max_received_linelength}{998}}
remote_smtp:
  message_size_limit = ${if > {$max_received_linelength}{998} {1}{0}}
```
because of
https://github.com/Exim/exim/commit/8c952127a4d1827ea14da68d94eb5ea8d6174a35
https://github.com/Exim/exim/commit/adb278a57214d0e0d691168330826d3dcad2161a

Added
```
dnslookup:
  ignore_target_hosts = 0.0.0.0 : 127.0.0.0/8
```
because of (security breach?)
http://www.exim.org/exim-html-3.20/doc/html/spec_27.html#SEC687