### PR TITLE
Fix v-update-letsencrypt-ssl idn domain and deleted aliases

### DIFF
--- a/bin/v-update-letsencrypt-ssl
+++ b/bin/v-update-letsencrypt-ssl
@@ -41,12 +41,9 @@ for user in $users; do
         expire=$((expire / 86400))
         domain=$(basename $crt |sed -e "s/.crt$//")
         if [[ "$expire" -lt 31 ]]; then
-            aliases=$(echo "$crt_data" |grep DNS:)
-            aliases=$(echo "$aliases" |sed -e "s/DNS://g" -e "s/,//")
-            aliases=$(echo "$aliases" |tr ' ' '\n' |sed "/^$/d")
-            aliases=$(echo "$aliases" |grep -v "^$domain$")
+            aliases=$(cat "$USER_DATA/web.conf" |grep "'$domain'")
+            aliases=$(echo "$aliases" |sed -e "s/.*ALIAS='\(.*\)/\1/" |cut -f 1 -d \')
             if [ ! -z "$aliases" ]; then
-                aliases=$(echo "$aliases" |sed -e ':a;N;$!ba;s/\n/,/g')
                 msg=$($BIN/v-add-letsencrypt-domain $user $domain $aliases)
                 if [ $? -ne 0 ]; then
                     echo "$domain $msg"


### PR DESCRIPTION
Error while updating certificates with idn domains and deleted aliases.
Error: domain *.xn--p1acf doesn't exist 
Error: domain deletedalias.com doesn't exist
Aliases to take in a config, instead of from the certificate.