### PR TITLE
Fixed NGINX Odoo templates do now allow adding/updating LetsEncrypt SSL.

### DIFF
--- a/install/debian/7/templates/web/nginx/php5-fpm/odoo.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/odoo.stpl
@@ -24,11 +24,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/debian/7/templates/web/nginx/php5-fpm/odoo.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/odoo.tpl
@@ -20,11 +20,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/debian/8/templates/web/nginx/php5-fpm/odoo.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/odoo.stpl
@@ -24,11 +24,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/debian/8/templates/web/nginx/php5-fpm/odoo.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/odoo.tpl
@@ -20,11 +20,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/debian/9/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/odoo.stpl
@@ -24,11 +24,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/debian/9/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/odoo.tpl
@@ -20,11 +20,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/rhel/5/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/odoo.stpl
@@ -24,11 +24,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/rhel/5/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/odoo.tpl
@@ -20,11 +20,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/rhel/6/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/odoo.stpl
@@ -24,11 +24,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/rhel/6/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/odoo.tpl
@@ -20,11 +20,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/rhel/7/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/odoo.stpl
@@ -24,11 +24,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/rhel/7/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/odoo.tpl
@@ -20,11 +20,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/odoo.stpl
@@ -24,11 +24,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/odoo.tpl
@@ -20,11 +20,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/odoo.stpl
@@ -24,11 +24,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/odoo.tpl
@@ -20,11 +20,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/odoo.stpl
@@ -24,11 +24,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/odoo.tpl
@@ -20,11 +20,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/odoo.stpl
@@ -24,11 +24,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/odoo.tpl
@@ -20,11 +20,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/odoo.stpl
@@ -24,11 +24,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/odoo.tpl
@@ -20,11 +20,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/odoo.stpl
@@ -24,11 +24,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/odoo.tpl
@@ -20,11 +20,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/odoo.stpl
@@ -24,11 +24,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/odoo.tpl
@@ -20,11 +20,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/odoo.stpl
@@ -24,11 +24,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/odoo.tpl
@@ -20,11 +20,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/odoo.stpl
@@ -24,11 +24,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/odoo.tpl
@@ -20,11 +20,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/odoo.stpl
@@ -24,11 +24,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/odoo.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/odoo.tpl
@@ -20,11 +20,6 @@ server {
     proxy_read_timeout      720;
     send_timeout            720;
 
-    # Allow "Well-Known URIs" as per RFC 5785
-    location ~* ^/.well-known/ {
-        allow all;
-    }
-
     location / {
         proxy_pass http://127.0.0.1:8069;
     }


### PR DESCRIPTION
Removed .well-known location as it conflicts with the .well-known location in *.conf_letsencrypt file