### PR TITLE
Deprecate quota hard limit

### DIFF
--- a/bin/v-update-user-quota
+++ b/bin/v-update-user-quota
@@ -31,10 +31,8 @@ is_object_valid 'user' 'USER' "$user"
 #----------------------------------------------------------#
 
 # Updating disk quota
-# Had quota equals package value. Soft quota equals 90% of package value for warnings.
 quota=$(get_user_value '$DISK_QUOTA')
-soft=$(echo "$quota * 1024 * 0.90"|bc |cut -f 1 -d .)
-hard=$(echo "$quota * 1024"|bc |cut -f 1 -d .)
+soft=$(echo "$quota * 1024"|bc |cut -f 1 -d .)
 
 # Searching home mount point
 mnt=$(df -P /home |awk '{print $6}' |tail -n1)
@@ -43,7 +41,7 @@ mnt=$(df -P /home |awk '{print $6}' |tail -n1)
 if [ "$quota" = 'unlimited' ]; then
     setquota $user 0 0 0 0 $mnt 2>/dev/null
 else
-    setquota $user $soft $hard 0 0 $mnt 2>/dev/null
+    setquota $user $soft 0 0 0 $mnt 2>/dev/null
 fi
 
 


### PR DESCRIPTION
Solves https://github.com/serghey-rodin/vesta/issues/1406

Grace period does not exist so soft limit is always applied. (Hard limit is only a temporary limit while grace period is not specified Ref: http://tldp.org/HOWTO/Quota-4.html#ss4.4)