### PR TITLE
Update v-update-host-certificate for restart exim & vsftpd

### DIFF
--- a/bin/v-update-host-certificate
+++ b/bin/v-update-host-certificate
@@ -76,6 +76,12 @@ $BIN/v-restart-mail
 if [ ! -z "$IMAP_SYSTEM" ]; then
     $BIN/v-restart-service "$IMAP_SYSTEM"
 fi
+if [ ! -z "$MAIL_SYSTEM" ]; then
+    $BIN/v-restart-service "$MAIL_SYSTEM"
+fi
+if [ ! -z "$FTP_SYSTEM" ]; then
+    $BIN/v-restart-service "$FTP_SYSTEM"
+fi
 if [ -f "/var/run/vesta-nginx.pid" ]; then
     kill -HUP $(cat /var/run/vesta-nginx.pid)
 fi


### PR DESCRIPTION
Restart mailserver & ftpserver based on `conf/vesta.conf` settings, so the new certificate will be applied.