### PR TITLE
 Add Wordpress WP Super Cache plugin template support

### DIFF
--- a/install/debian/7/templates/web/nginx/php5-fpm/wordpress2_wp_super_cache.stpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/wordpress2_wp_super_cache.stpl
@@ -1,0 +1,89 @@
+server {
+    listen      %ip%:%web_ssl_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %sdocroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    ssl         on;
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+    
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index-https.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/snginx.%domain%.conf*;
+}

--- a/install/debian/7/templates/web/nginx/php5-fpm/wordpress2_wp_super_cache.tpl
+++ b/install/debian/7/templates/web/nginx/php5-fpm/wordpress2_wp_super_cache.tpl
@@ -1,0 +1,85 @@
+server {
+    listen      %ip%:%web_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+    
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/nginx.%domain%.conf*;
+}

--- a/install/debian/8/templates/web/nginx/php5-fpm/wordpress2_wp_super_cache.stpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/wordpress2_wp_super_cache.stpl
@@ -1,0 +1,89 @@
+server {
+    listen      %ip%:%web_ssl_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %sdocroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    ssl         on;
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+    
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index-https.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/snginx.%domain%.conf*;
+}

--- a/install/debian/8/templates/web/nginx/php5-fpm/wordpress2_wp_super_cache.tpl
+++ b/install/debian/8/templates/web/nginx/php5-fpm/wordpress2_wp_super_cache.tpl
@@ -1,0 +1,85 @@
+server {
+    listen      %ip%:%web_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+    
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/nginx.%domain%.conf*;
+}

--- a/install/debian/9/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
@@ -1,0 +1,89 @@
+server {
+    listen      %ip%:%web_ssl_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %sdocroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    ssl         on;
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+    
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index-https.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/snginx.%domain%.conf*;
+}

--- a/install/debian/9/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
+++ b/install/debian/9/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
@@ -1,0 +1,85 @@
+server {
+    listen      %ip%:%web_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+    
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/nginx.%domain%.conf*;
+}

--- a/install/rhel/5/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
@@ -1,0 +1,89 @@
+server {
+    listen      %ip%:%web_ssl_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %sdocroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    ssl         on;
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+    
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index-https.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/snginx.%domain%.conf*;
+}

--- a/install/rhel/5/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
+++ b/install/rhel/5/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
@@ -1,0 +1,85 @@
+server {
+    listen      %ip%:%web_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+    
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/nginx.%domain%.conf*;
+}

--- a/install/rhel/6/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
@@ -1,0 +1,89 @@
+server {
+    listen      %ip%:%web_ssl_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %sdocroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    ssl         on;
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+    
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index-https.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/snginx.%domain%.conf*;
+}

--- a/install/rhel/6/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
+++ b/install/rhel/6/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
@@ -1,0 +1,85 @@
+server {
+    listen      %ip%:%web_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+    
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/nginx.%domain%.conf*;
+}

--- a/install/rhel/7/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
@@ -1,0 +1,89 @@
+server {
+    listen      %ip%:%web_ssl_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %sdocroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    ssl         on;
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+    
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index-https.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/snginx.%domain%.conf*;
+}

--- a/install/rhel/7/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
+++ b/install/rhel/7/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
@@ -1,0 +1,85 @@
+server {
+    listen      %ip%:%web_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+    
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/nginx.%domain%.conf*;
+}

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
@@ -1,0 +1,89 @@
+server {
+    listen      %ip%:%web_ssl_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %sdocroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    ssl         on;
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+    
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index-https.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/snginx.%domain%.conf*;
+}

--- a/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
@@ -1,0 +1,85 @@
+server {
+    listen      %ip%:%web_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+    
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/nginx.%domain%.conf*;
+}

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
@@ -1,0 +1,89 @@
+server {
+    listen      %ip%:%web_ssl_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %sdocroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    ssl         on;
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+    
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index-https.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/snginx.%domain%.conf*;
+}

--- a/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
@@ -1,0 +1,85 @@
+server {
+    listen      %ip%:%web_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+    
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/nginx.%domain%.conf*;
+}

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
@@ -1,0 +1,89 @@
+server {
+    listen      %ip%:%web_ssl_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %sdocroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    ssl         on;
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+    
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index-https.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/snginx.%domain%.conf*;
+}

--- a/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
@@ -1,0 +1,85 @@
+server {
+    listen      %ip%:%web_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+    
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/nginx.%domain%.conf*;
+}

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
@@ -1,0 +1,89 @@
+server {
+    listen      %ip%:%web_ssl_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %sdocroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    ssl         on;
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+    
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index-https.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/snginx.%domain%.conf*;
+}

--- a/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
@@ -1,0 +1,85 @@
+server {
+    listen      %ip%:%web_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+    
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/nginx.%domain%.conf*;
+}

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
@@ -1,0 +1,89 @@
+server {
+    listen      %ip%:%web_ssl_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %sdocroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    ssl         on;
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+    
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index-https.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/snginx.%domain%.conf*;
+}

--- a/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
@@ -1,0 +1,85 @@
+server {
+    listen      %ip%:%web_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+    
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/nginx.%domain%.conf*;
+}

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
@@ -1,0 +1,89 @@
+server {
+    listen      %ip%:%web_ssl_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %sdocroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    ssl         on;
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+    
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index-https.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/snginx.%domain%.conf*;
+}

--- a/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
@@ -1,0 +1,85 @@
+server {
+    listen      %ip%:%web_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+    
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/nginx.%domain%.conf*;
+}

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
@@ -1,0 +1,89 @@
+server {
+    listen      %ip%:%web_ssl_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %sdocroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    ssl         on;
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+    
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index-https.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/snginx.%domain%.conf*;
+}

--- a/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
@@ -1,0 +1,85 @@
+server {
+    listen      %ip%:%web_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+    
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/nginx.%domain%.conf*;
+}

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
@@ -1,0 +1,89 @@
+server {
+    listen      %ip%:%web_ssl_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %sdocroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    ssl         on;
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+    
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index-https.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/snginx.%domain%.conf*;
+}

--- a/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
@@ -1,0 +1,85 @@
+server {
+    listen      %ip%:%web_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+    
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/nginx.%domain%.conf*;
+}

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
@@ -1,0 +1,89 @@
+server {
+    listen      %ip%:%web_ssl_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %sdocroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    ssl         on;
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+    
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index-https.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/snginx.%domain%.conf*;
+}

--- a/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
@@ -1,0 +1,85 @@
+server {
+    listen      %ip%:%web_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+    
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/nginx.%domain%.conf*;
+}

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.stpl
@@ -1,0 +1,89 @@
+server {
+    listen      %ip%:%web_ssl_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %sdocroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    ssl         on;
+    ssl_certificate      %ssl_pem%;
+    ssl_certificate_key  %ssl_key%;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+    
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index-https.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/snginx.%domain%.conf*;
+}

--- a/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/php-fpm/wordpress2_wp_super_cache.tpl
@@ -1,0 +1,85 @@
+server {
+    listen      %ip%:%web_port%;
+    server_name %domain_idn% %alias_idn%;
+    root        %docroot%;
+    index       index.php index.html index.htm;
+    access_log  /var/log/nginx/domains/%domain%.log combined;
+    access_log  /var/log/nginx/domains/%domain%.bytes bytes;
+    error_log   /var/log/nginx/domains/%domain%.error.log error;
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+    
+    set $cache_uri $request_uri;
+
+    if ($request_method = POST) {
+        set $cache_uri 'null cache';
+    }
+
+    if ($query_string != "") {
+        set $cache_uri 'null cache';
+    }   
+
+    if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|/wp-(app|cron|login|register|mail).php
+                          |wp-.*.php|/feed/|index.php|wp-comments-popup.php
+                          |wp-links-opml.php|wp-locations.php |sitemap(_index)?.xml
+                          |[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+        set $cache_uri 'null cache';
+    }  
+
+    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+
+                         |wp-postpass|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_") {
+        set $cache_uri 'null cache';
+    }
+
+    location / {
+        try_files /wp-content/cache/supercache/$http_host/$cache_uri/index.html $uri $uri/ /index.php?$args;
+
+        location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
+            expires     max;
+        }
+
+        location ~ [^/]\.php(/|$) {
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            if (!-f $document_root$fastcgi_script_name) {
+                return  404;
+            }
+
+            fastcgi_pass    %backend_lsnr%;
+            fastcgi_index   index.php;
+            include         /etc/nginx/fastcgi_params;
+        }
+    }
+
+    error_page  403 /error/404.html;
+    error_page  404 /error/404.html;
+    error_page  500 502 503 504 /error/50x.html;
+
+    location /error/ {
+        alias   %home%/%user%/web/%domain%/document_errors/;
+    }
+
+    location ~* "/\.(htaccess|htpasswd)$" {
+        deny    all;
+        return  404;
+    }
+
+    location /vstats/ {
+        alias   %home%/%user%/web/%domain%/stats/;
+        include %home%/%user%/conf/web/%domain%.auth*;
+    }
+
+    include     /etc/nginx/conf.d/phpmyadmin.inc*;
+    include     /etc/nginx/conf.d/phppgadmin.inc*;
+    include     /etc/nginx/conf.d/webmail.inc*;
+
+    include     %home%/%user%/conf/web/nginx.%domain%.conf*;
+}


### PR DESCRIPTION
Add Wordpress WP Super Cache plugin template support as Wordpress default template from VestaCP doesn't have cache support and we need to modify location / block especially to check if the cache file exist (try_files)