### PR TITLE
TXT & SPF input longer than 255 characters

### DIFF
--- a/web/add/dns/index.php
+++ b/web/add/dns/index.php
@@ -111,6 +111,13 @@ if (!empty($_POST['ok_rec'])) {
         $_SESSION['error_msg'] = __('Field "%s" can not be blank.',$error_msg);
     }
 
+    // Don't allow SPF and TXT longer than 255
+    if ($_POST['v_type'] == 'TXT' || $_POST['v_type'] == 'SPF') {
+        if (strlen($_POST['v_val']) > 255) {
+            $_SESSION['error_msg'] = __(htmlentities($_POST[v_type]) . ' can\'t contain more than 255 characters.');
+        }
+    }
+    
     // Protect input
     $v_domain = escapeshellarg($_POST['v_domain']);
     $v_rec = escapeshellarg($_POST['v_rec']);

--- a/web/add/dns/index.php
+++ b/web/add/dns/index.php
@@ -28,31 +28,6 @@ if (!empty($_POST['ok'])) {
         }
         $_SESSION['error_msg'] = __('Field "%s" can not be blank.',$error_msg);
     }
-
-    // Split TXT and SPF records longer than 255 char
-   
-    if ($_POST['v_type'] == 'TXT' || $_POST['v_type'] == 'SPF') {
-        if (strlen($_POST['v_val']) > 255) {
-            
-            // Escape semicolon and get rid of double quotes
-            $v_val = strtr($_POST['v_val'], array(';' => '\; ', '"' => ''));
-            
-            // Strip new lines
-            $v_val = str_replace(array("\r", "\n"), '', $v_val);
-			
-			// Strip to array
-            $v_val = str_split($v_val, 255);
-			
-			$final = '(';
-            foreach ($v_val as $i => $chunk) {
-                $final .= " \"" . $chunk . "\" ";
-            }
-            $final .= ')';
-			$v_val = $final;
-        }
-    } else {
-        $v_val = $_POST['v_val'];
-    }
     
     // Protect input
     $v_domain = preg_replace("/^www./i", "", $_POST['v_domain']);
@@ -136,11 +111,29 @@ if (!empty($_POST['ok_rec'])) {
         $_SESSION['error_msg'] = __('Field "%s" can not be blank.',$error_msg);
     }
 
-    // Don't allow SPF and TXT longer than 255
+    // Split TXT and SPF records longer than 255 char
+   
     if ($_POST['v_type'] == 'TXT' || $_POST['v_type'] == 'SPF') {
         if (strlen($_POST['v_val']) > 255) {
-            $_SESSION['error_msg'] = __(htmlentities($_POST[v_type]) . ' can\'t contain more than 255 characters.');
+            
+            // Escape semicolon and get rid of double quotes
+            $v_val = strtr($_POST['v_val'], array(';' => '\; ', '"' => ''));
+            
+            // Strip new lines
+            $v_val = str_replace(array("\r", "\n"), '', $v_val);
+			
+			// Strip to array
+            $v_val = str_split($v_val, 255);
+			
+			$final = '(';
+            foreach ($v_val as $i => $chunk) {
+                $final .= " \"" . $chunk . "\" ";
+            }
+            $final .= ')';
+			$v_val = $final;
         }
+    } else {
+        $v_val = $_POST['v_val'];
     }
     
     // Protect input

--- a/web/add/dns/index.php
+++ b/web/add/dns/index.php
@@ -113,28 +113,28 @@ if (!empty($_POST['ok_rec'])) {
 
     // Split TXT and SPF records longer than 255 char
    
-    if ($_POST['v_type'] == 'TXT' || $_POST['v_type'] == 'SPF') {
-        if (strlen($_POST['v_val']) > 255) {
-            
-            // Escape semicolon and get rid of double quotes
-            $v_val = strtr($_POST['v_val'], array(';' => '\; ', '"' => ''));
-            
-            // Strip new lines
-            $v_val = str_replace(array("\r", "\n"), '', $v_val);
-			
-			// Strip to array
-            $v_val = str_split($v_val, 255);
-			
+	if ($_POST['v_type'] == 'TXT' || $_POST['v_type'] == 'SPF') {
+		if (strlen($_POST['v_val']) > 255) {
+
+			// Escape semicolon and get rid of double quotes
+			$v_val = strtr($_POST['v_val'], array(';' => '\; ', '"' => ''));
+
+			// Strip new lines
+			$v_val = str_replace(array("\r", "\n"), '', $v_val);
+
+			// Divide in array chunks 255 char. long
+			$v_val = str_split($v_val, 255);
+
 			$final = '(';
-            foreach ($v_val as $i => $chunk) {
-                $final .= " \"" . $chunk . "\" ";
-            }
-            $final .= ')';
+			foreach ($v_val as $i => $chunk) {
+				$final .= " \"" . $chunk . "\" ";
+			}
+			$final .= ')';
 			$v_val = $final;
-        }
-    } else {
-        $v_val = $_POST['v_val'];
-    }
+		}
+	} else {
+		$v_val = $_POST['v_val'];
+	}
     
     // Protect input
     $v_domain = escapeshellarg($_POST['v_domain']);

--- a/web/add/dns/index.php
+++ b/web/add/dns/index.php
@@ -29,6 +29,31 @@ if (!empty($_POST['ok'])) {
         $_SESSION['error_msg'] = __('Field "%s" can not be blank.',$error_msg);
     }
 
+    // Split TXT and SPF records longer than 255 char
+   
+    if ($_POST['v_type'] == 'TXT' || $_POST['v_type'] == 'SPF') {
+        if (strlen($_POST['v_val']) > 255) {
+            
+            // Escape semicolon and get rid of double quotes
+            $v_val = strtr($_POST['v_val'], array(';' => '\; ', '"' => ''));
+            
+            // Strip new lines
+            $v_val = str_replace(array("\r", "\n"), '', $v_val);
+			
+			// Strip to array
+            $v_val = str_split($v_val, 255);
+			
+			$final = '(';
+            foreach ($v_val as $i => $chunk) {
+                $final .= " \"" . $chunk . "\" ";
+            }
+            $final .= ')';
+			$v_val = $final;
+        }
+    } else {
+        $v_val = $_POST['v_val'];
+    }
+    
     // Protect input
     $v_domain = preg_replace("/^www./i", "", $_POST['v_domain']);
     $v_domain = escapeshellarg($v_domain);


### PR DESCRIPTION
Temporary fix.

https://github.com/serghey-rodin/vesta/issues/1551

I was trying to make a fix but unsuccessful, this was the idea:

```
    if ($_POST['v_type'] == 'TXT' || $_POST['v_type'] == 'SPF') {
        if (strlen($_POST['v_val']) > 255) {
            $v_val = strtr($_POST['v_val'], array(';' => '\; ', '"' => ''));
            $v_val = "(\"" . chunk_split($v_val,255,"\" \"") . "\")";
        }
    } else {
        $v_val = $_POST['v_val'];
    }
```