### PR TITLE
Fix rebuild-web-domain deleting all includes in /etc/*/conf.d/vesta.conf for some usernames

### DIFF
--- a/bin/v-rebuild-web-domains
+++ b/bin/v-rebuild-web-domains
@@ -37,7 +37,7 @@ is_object_unsuspended 'user' 'USER' "$user"
 #----------------------------------------------------------#
 
 # Deleting old web configs
-sed -i "/.*\/$user\//d" /etc/$WEB_SYSTEM/conf.d/vesta.conf
+sed -i "/.*\/$user\/conf\/web\//d" /etc/$WEB_SYSTEM/conf.d/vesta.conf
 if [ -e "$HOMEDIR/$user/conf/web/$WEB_SYSTEM.conf"  ]; then
     rm $HOMEDIR/$user/conf/web/$WEB_SYSTEM.conf
 fi
@@ -47,7 +47,7 @@ fi
 
 # Deleting old proxy configs
 if [ ! -z "$PROXY_SYSTEM" ]; then
-    sed -i "/.*\/$user\//d" /etc/$PROXY_SYSTEM/conf.d/vesta.conf
+    sed -i "/.*\/$user\/conf\/web\//d" /etc/$PROXY_SYSTEM/conf.d/vesta.conf
 
     if [ -e "$HOMEDIR/$user/conf/web/$PROXY_SYSTEM.conf" ]; then
         rm $HOMEDIR/$user/conf/web/$PROXY_SYSTEM.conf


### PR DESCRIPTION
If someone creates an user named "conf" or "web", when that user rebuilds its web domains all lines with "include" on /etc/httpd/conf.d/vesta.conf and /etc/nginx/conf.d/vesta.conf for the virtualhosts would be deleted and then would only add its "include" rules for the domain being rebuild.

The other users wouldn't have any website working any more, they would have to rebuild their web domains too to fix it.

It includes another PR that it's approved, so I guess there's no problem including it here.

PS: resubmitted from #1293 