### PR TITLE
Do not allow {tab} as a valid character for a domain

### DIFF
--- a/func/main.sh
+++ b/func/main.sh
@@ -532,7 +532,7 @@ is_user_format_valid() {
 is_domain_format_valid() {
     object_name=${2-domain}
     exclude="[!|@|#|$|^|&|*|(|)|+|=|{|}|:|,|<|>|?|_|/|\|\"|'|;|%|\`| ]"
-    if [[ $1 =~ $exclude ]] || [[ $1 =~ ^[0-9]+$ ]] || [[ $1 =~ "\.\." ]]; then
+    if [[ $1 =~ $exclude ]] || [[ $1 =~ ^[0-9]+$ ]] || [[ $1 =~ "\.\." ]] || [[ $1 =~ "$(printf '\t')" ]]; then
         check_result $E_INVALID "invalid $object_name format :: $1"
     fi
 }


### PR DESCRIPTION
Right now it is possible to add 'tab key' to a domain, breaking several services like apache, nginx and named, for example.

The name files for serveral configuration files are wrong, and services can't start because of them.

This adds and additional check on the format of the domain.

PS: Resubmitted from #1562