### PR TITLE
Roundcube Vesta password driver fix for Ubuntu 12.04-16.10 and Debian 7

### DIFF
--- a/install/debian/7/roundcube/vesta.php
+++ b/install/debian/7/roundcube/vesta.php
@@ -7,7 +7,8 @@
  * @author Serghey Rodin <skid@vestacp.com>
  */
 
-    function password_save($curpass, $passwd)
+class rcube_vesta_password {
+    function save($curpass, $passwd)
     {
         $rcmail = rcmail::get_instance();
         $vesta_host = $rcmail->config->get('password_vesta_host');
@@ -60,3 +61,4 @@
         }
 
     }
+}

--- a/install/ubuntu/12.04/roundcube/vesta.php
+++ b/install/ubuntu/12.04/roundcube/vesta.php
@@ -7,7 +7,8 @@
  * @author Serghey Rodin <skid@vestacp.com>
  */
 
-    function password_save($curpass, $passwd)
+class rcube_vesta_password {
+    function save($curpass, $passwd)
     {
         $rcmail = rcmail::get_instance();
         $vesta_host = $rcmail->config->get('password_vesta_host');
@@ -60,3 +61,4 @@
         }
 
     }
+}

--- a/install/ubuntu/12.10/roundcube/vesta.php
+++ b/install/ubuntu/12.10/roundcube/vesta.php
@@ -7,7 +7,8 @@
  * @author Serghey Rodin <skid@vestacp.com>
  */
 
-    function password_save($curpass, $passwd)
+class rcube_vesta_password {
+    function save($curpass, $passwd)
     {
         $rcmail = rcmail::get_instance();
         $vesta_host = $rcmail->config->get('password_vesta_host');
@@ -60,3 +61,4 @@
         }
 
     }
+}

--- a/install/ubuntu/13.04/roundcube/vesta.php
+++ b/install/ubuntu/13.04/roundcube/vesta.php
@@ -7,7 +7,8 @@
  * @author Serghey Rodin <skid@vestacp.com>
  */
 
-    function password_save($curpass, $passwd)
+class rcube_vesta_password {
+    function save($curpass, $passwd)
     {
         $rcmail = rcmail::get_instance();
         $vesta_host = $rcmail->config->get('password_vesta_host');
@@ -60,3 +61,4 @@
         }
 
     }
+}

--- a/install/ubuntu/13.10/roundcube/vesta.php
+++ b/install/ubuntu/13.10/roundcube/vesta.php
@@ -7,7 +7,8 @@
  * @author Serghey Rodin <skid@vestacp.com>
  */
 
-    function password_save($curpass, $passwd)
+class rcube_vesta_password {
+    function save($curpass, $passwd)
     {
         $rcmail = rcmail::get_instance();
         $vesta_host = $rcmail->config->get('password_vesta_host');
@@ -60,3 +61,4 @@
         }
 
     }
+}

--- a/install/ubuntu/14.04/roundcube/vesta.php
+++ b/install/ubuntu/14.04/roundcube/vesta.php
@@ -7,7 +7,8 @@
  * @author Serghey Rodin <skid@vestacp.com>
  */
 
-    function password_save($curpass, $passwd)
+class rcube_vesta_password {
+    function save($curpass, $passwd)
     {
         $rcmail = rcmail::get_instance();
         $vesta_host = $rcmail->config->get('password_vesta_host');
@@ -60,3 +61,4 @@
         }
 
     }
+}

--- a/install/ubuntu/14.10/roundcube/vesta.php
+++ b/install/ubuntu/14.10/roundcube/vesta.php
@@ -7,7 +7,8 @@
  * @author Serghey Rodin <skid@vestacp.com>
  */
 
-    function password_save($curpass, $passwd)
+class rcube_vesta_password {
+    function save($curpass, $passwd)
     {
         $rcmail = rcmail::get_instance();
         $vesta_host = $rcmail->config->get('password_vesta_host');
@@ -60,3 +61,4 @@
         }
 
     }
+}

--- a/install/ubuntu/15.04/roundcube/vesta.php
+++ b/install/ubuntu/15.04/roundcube/vesta.php
@@ -7,7 +7,8 @@
  * @author Serghey Rodin <skid@vestacp.com>
  */
 
-    function password_save($curpass, $passwd)
+class rcube_vesta_password {
+    function save($curpass, $passwd)
     {
         $rcmail = rcmail::get_instance();
         $vesta_host = $rcmail->config->get('password_vesta_host');
@@ -60,3 +61,4 @@
         }
 
     }
+}

--- a/install/ubuntu/15.10/roundcube/vesta.php
+++ b/install/ubuntu/15.10/roundcube/vesta.php
@@ -7,7 +7,8 @@
  * @author Serghey Rodin <skid@vestacp.com>
  */
 
-    function password_save($curpass, $passwd)
+class rcube_vesta_password {
+    function save($curpass, $passwd)
     {
         $rcmail = rcmail::get_instance();
         $vesta_host = $rcmail->config->get('password_vesta_host');
@@ -60,3 +61,4 @@
         }
 
     }
+}

--- a/install/ubuntu/16.04/roundcube/vesta.php
+++ b/install/ubuntu/16.04/roundcube/vesta.php
@@ -7,7 +7,8 @@
  * @author Serghey Rodin <skid@vestacp.com>
  */
 
-    function password_save($curpass, $passwd)
+class rcube_vesta_password {
+    function save($curpass, $passwd)
     {
         $rcmail = rcmail::get_instance();
         $vesta_host = $rcmail->config->get('password_vesta_host');
@@ -69,3 +70,4 @@
         }
 
     }
+}

--- a/install/ubuntu/16.10/roundcube/vesta.php
+++ b/install/ubuntu/16.10/roundcube/vesta.php
@@ -6,8 +6,8 @@
  * @version 1.0
  * @author Serghey Rodin <skid@vestacp.com>
  */
-
-    function password_save($curpass, $passwd)
+class rcube_vesta_password {
+    function save($curpass, $passwd)
     {
         $rcmail = rcmail::get_instance();
         $vesta_host = $rcmail->config->get('password_vesta_host');
@@ -69,3 +69,4 @@
         }
 
     }
+}


### PR DESCRIPTION
I have encountered this Roundcube password driver `vesta.php` issue in a fresh installation on Ubuntu 16.04 and fixed it following this [thread in the VestaCP forum](https://forum.vestacp.com/viewtopic.php?f=12&t=10114&p=39648#p38630). 

After checking the repo, it appears the fix has only been applied to RHEL and Debian 8. The whole series of Ubuntu distro has been left as is. This pull request intends to bring the Roundcube password driver `vesta.php` in all supported distros to the latest format required by Roundcube. 