### PR TITLE
Adding and removing includes when suspending/unsuspending DNS zones

### DIFF
--- a/bin/v-suspend-dns-domain
+++ b/bin/v-suspend-dns-domain
@@ -41,6 +41,16 @@ is_object_unsuspended 'dns' 'DOMAIN' "$domain"
 #                       Action                             #
 #----------------------------------------------------------#
 
+# Deleting system configs
+if [[ "$DNS_SYSTEM" =~ named|bind ]]; then
+    if [ -e '/etc/named.conf' ]; then
+        dns_conf='/etc/named.conf'
+    else
+        dns_conf='/etc/bind/named.conf'
+    fi
+
+    sed -i "/\/$user\/conf\/dns\/$domain.db\"/d" $dns_conf
+fi
 
 #----------------------------------------------------------#
 #                       Vesta                              #

--- a/bin/v-unsuspend-dns-domain
+++ b/bin/v-unsuspend-dns-domain
@@ -40,7 +40,21 @@ is_object_suspended 'dns' 'DOMAIN' "$domain"
 #                       Action                             #
 #----------------------------------------------------------#
 
+# Creating system configs
+if [[ "$DNS_SYSTEM" =~ named|bind ]]; then
+    if [ -e '/etc/named.conf' ]; then
+        dns_conf='/etc/named.conf'
+        dns_group='named'
+    else
+        dns_conf='/etc/bind/named.conf'
+        dns_group='bind'
+    fi
 
+    # Adding zone in named.conf
+    named="zone \"$domain_idn\" {type master; file"
+    named="$named \"$HOMEDIR/$user/conf/dns/$domain.db\";};"
+    echo "$named" >> $dns_conf
+fi
 
 #----------------------------------------------------------#
 #                       Vesta                              #


### PR DESCRIPTION
Trying to fix issue #1573

When suspending or unsuspending a DNS domain, it doesn't modify it's lines on the includes (/etc/named.conf on CentOS) so the DNS zone can be reached.
Only rebuilding DNS domain fixes the problem.

This commit adds and remove those includes when needed, the same way when you add a dns domain or remove it.