### PR TITLE
Fix Adding alias DNS from web panel

### DIFF
--- a/bin/v-add-dns-on-web-alias
+++ b/bin/v-add-dns-on-web-alias
@@ -50,12 +50,12 @@ domain_lvl=$(echo "$alias" |grep -o "\." |wc -l)
 # Adding second level domain
 if [ "$domain_lvl" -eq 1 ] || [ "${#top_domain}" -le '6' ]; then
     $BIN/v-add-dns-domain \
-        $user $alias $ip '' '' '' '' '' $restart >> /dev/null
+        $user $alias $ip '' '' '' '' '' '' '' '' $restart >> /dev/null
     exit
 fi
 
 # Adding top-level domain and then its sub
-$BIN/v-add-dns-domain $user $top_domain $ip '' '' '' '' $restart >> /dev/null
+$BIN/v-add-dns-domain $user $top_domain $ip '' '' '' '' '' $restart >> /dev/null
 
 # Checking top-level domain
 if [ ! -e "$USER_DATA/dns/$top_domain.conf" ]; then


### PR DESCRIPTION
When adding an alias from the web interface, it added 1 extra NS record pointing to "no".
Fixed number of parameters passed from v-add-dns-on-web-alias to v-add-dns-domain so it doesn't add that NS when its the 'no' restart option