### PR TITLE
open_basedir restriction for php-fpm backend

### DIFF
--- a/bin/v-add-web-domain-backend
+++ b/bin/v-add-web-domain-backend
@@ -14,6 +14,7 @@ user=$1
 domain=$2
 template=${3-default}
 restart=$4
+docroot="$HOMEDIR/$user/web/$domain/public_html"
 
 # Includes
 source $VESTA/func/main.sh
@@ -59,6 +60,7 @@ cat $WEBTPL/$WEB_BACKEND/$template.tpl |\
     sed -e "s|%backend_port%|$backend_port|" \
         -e "s|%user%|$user|g"\
         -e "s|%domain%|$domain|g"\
+        -e "s|%docroot%|$docroot|g"\
         -e "s|%backend%|$backend_type|g" > $pool/$backend_type.conf
 
 

--- a/bin/v-change-web-domain-backend-tpl
+++ b/bin/v-change-web-domain-backend-tpl
@@ -15,6 +15,7 @@ domain=$2
 domain_idn=$2
 template=$3
 restart=$4
+docroot="$HOMEDIR/$user/web/$domain/public_html"
 
 # Includes
 source $VESTA/func/main.sh
@@ -65,6 +66,7 @@ cat $WEBTPL/$WEB_BACKEND/$template.tpl |\
     sed -e "s|%backend_port%|$backend_port|" \
         -e "s|%user%|$user|g"\
         -e "s|%domain%|$domain|g"\
+        -e "s|%docroot%|$docroot|g"\
         -e "s|%domain_idn%|$domain_idn|"\
         -e "s|%backend%|$backend_type|g" > $pool/$backend_type.conf
 

--- a/install/ubuntu/16.04/templates/web/php-fpm/default.tpl
+++ b/install/ubuntu/16.04/templates/web/php-fpm/default.tpl
@@ -13,6 +13,7 @@ pm.status_path = /status
 
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
+php_admin_value[open_basedir] = %docroot%:/home/%user%/tmp
 
 env[HOSTNAME] = $HOSTNAME
 env[PATH] = /usr/local/bin:/usr/bin:/bin


### PR DESCRIPTION
Useful to set open_basedir restrictions for php-fpm backend, like in apache templates.

Maybe this should be a separate template if you don't want this functionality in default.tpl