### PR TITLE
Fixing the change password for Roundcube to work with Ubuntu

### DIFF
--- a/install/ubuntu/16.04/roundcube/vesta.php
+++ b/install/ubuntu/16.04/roundcube/vesta.php
@@ -6,8 +6,9 @@
  * @version 1.0
  * @author Serghey Rodin <skid@vestacp.com>
  */
-
-    function password_save($curpass, $passwd)
+class rcube_vesta_password
+{
+    function save($curpass, $passwd)
     {
         $rcmail = rcmail::get_instance();
         $vesta_host = $rcmail->config->get('password_vesta_host');
@@ -69,3 +70,4 @@
         }
 
     }
+}

--- a/install/ubuntu/16.10/roundcube/vesta.php
+++ b/install/ubuntu/16.10/roundcube/vesta.php
@@ -6,8 +6,8 @@
  * @version 1.0
  * @author Serghey Rodin <skid@vestacp.com>
  */
-
-    function password_save($curpass, $passwd)
+class rcube_vesta_password {
+    function save($curpass, $passwd)
     {
         $rcmail = rcmail::get_instance();
         $vesta_host = $rcmail->config->get('password_vesta_host');
@@ -69,3 +69,4 @@
         }
 
     }
+}

--- a/install/ubuntu/17.04/roundcube/vesta.php
+++ b/install/ubuntu/17.04/roundcube/vesta.php
@@ -6,8 +6,9 @@
  * @version 1.0
  * @author Serghey Rodin <skid@vestacp.com>
  */
-
-    function password_save($curpass, $passwd)
+class rcube_vesta_password
+{
+    function save($curpass, $passwd)
     {
         $rcmail = rcmail::get_instance();
         $vesta_host = $rcmail->config->get('password_vesta_host');
@@ -69,3 +70,4 @@
         }
 
     }
+}

--- a/install/ubuntu/17.10/roundcube/vesta.php
+++ b/install/ubuntu/17.10/roundcube/vesta.php
@@ -6,8 +6,8 @@
  * @version 1.0
  * @author Serghey Rodin <skid@vestacp.com>
  */
-
-    function password_save($curpass, $passwd)
+class rcube_vesta_password {
+    function save($curpass, $passwd)
     {
         $rcmail = rcmail::get_instance();
         $vesta_host = $rcmail->config->get('password_vesta_host');
@@ -69,3 +69,4 @@
         }
 
     }
+}

--- a/install/ubuntu/18.04/roundcube/vesta.php
+++ b/install/ubuntu/18.04/roundcube/vesta.php
@@ -6,8 +6,8 @@
  * @version 1.0
  * @author Serghey Rodin <skid@vestacp.com>
  */
-
-    function password_save($curpass, $passwd)
+class rcube_vesta_password {
+    function save($curpass, $passwd)
     {
         $rcmail = rcmail::get_instance();
         $vesta_host = $rcmail->config->get('password_vesta_host');
@@ -69,3 +69,4 @@
         }
 
     }
+}


### PR DESCRIPTION
This is a fix for the "password change" plugin for Roundcube. The issue is outlined here: https://github.com/serghey-rodin/vesta/issues/909 and fixed for CentOS but the Ubuntu repository and files were not changed.

The Roundcube vesta password plugin does not work with the new Roundcube version and this fixes it. 