### PR TITLE
Fast fix for automatic update

### DIFF
--- a/bin/v-update-sys-vesta
+++ b/bin/v-update-sys-vesta
@@ -33,7 +33,7 @@ check_args '1' "$#" 'PACKAGE'
 #                       Action                             #
 #----------------------------------------------------------#
 
-if [ -d "/etc/sysconfig" ]; then
+if [ -f "/usr/bin/yum" ]; then
     # Clean yum chache
     yum -q clean all
 


### PR DESCRIPTION
Hello! Fast dirty fix for yum-based distros

Do not use /etc/sysconfig, because some packages on deb-based also have this directory. For example

```
apt-file search /etc/sysconfig
rhn-client-tools: /etc/sysconfig/rhn/up2date
rhnsd: /etc/sysconfig/rhn/rhnsd
```

And this fail install with error

```
/usr/local/vesta/bin/v-update-sys-vesta: line 38: yum: command not found
```

Thanks.