### PR TITLE
Replace dynamic with ondemand and fine tuning

### DIFF
--- a/src/rpm/conf/php-fpm.conf
+++ b/src/rpm/conf/php-fpm.conf
@@ -1,20 +1,26 @@
 [global]
 pid = /var/run/vesta-php.pid
+syslog.ident = vesta-php
 daemonize = yes
+emergency_restart_threshold = 10
+emergency_restart_interval = 60s
+process_control_timeout = 10s
+events.mechanism = epoll
 
 [www]
+listen = /var/run/vesta-php.sock
+
 user = admin
 group = admin
-listen = /var/run/vesta-php.sock
+
 listen.owner = admin
 listen.group = admin
 listen.mode = 0660
 
-pm = dynamic
-pm.max_children = 5
-pm.start_servers = 2
-pm.min_spare_servers = 1
-pm.max_spare_servers = 3
+pm = ondemand
+pm.max_children = 4
+pm.max_requests = 1000
+pm.process_idle_timeout = 10s;
 
 env[HOSTNAME] = $HOSTNAME
 env[PATH] = /usr/local/bin:/usr/bin:/bin
@@ -23,6 +29,7 @@ env[TMPDIR] = /tmp
 env[TEMP] = /tmp
 env[VESTA] = $VESTA
 env[LANG] = en_US.UTF-8
+
 php_flag[display_errors] = off
 php_admin_value[error_log] = /usr/local/vesta/log/fpm-php.log
 php_admin_flag[log_errors] = on


### PR DESCRIPTION
Ondemand is better suited for Vesta since there is no reason to keep connections alive and use resources.