### PR TITLE
Disable TLSv1 (no longer supported)

### DIFF
--- a/install/ubuntu/18.04/dovecot/conf.d/10-ssl.conf
+++ b/install/ubuntu/18.04/dovecot/conf.d/10-ssl.conf
@@ -1,5 +1,5 @@
 ssl = yes
-ssl_protocols = !SSLv2 !SSLv3
+ssl_protocols = !SSLv2 !SSLv3 !TLSv1
 
 ssl_cert = </usr/local/vesta/ssl/certificate.crt
 ssl_key = </usr/local/vesta/ssl/certificate.key


### PR DESCRIPTION
As of 01/07/2018, TLSv1 is no longer supported.