### PR TITLE
Fix Templates nginx "ssl" directive is deprecated

### DIFF
--- a/install/ubuntu/18.04/templates/web/nginx/caching.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/caching.stpl
@@ -1,7 +1,6 @@
 server {
-    listen      %ip%:%proxy_ssl_port%;
+    listen      %ip%:%proxy_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;

--- a/install/ubuntu/18.04/templates/web/nginx/default.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/default.stpl
@@ -1,7 +1,6 @@
 server {
-    listen      %ip%:%proxy_ssl_port%;
+    listen      %ip%:%proxy_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;

--- a/install/ubuntu/18.04/templates/web/nginx/hosting.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/hosting.stpl
@@ -1,7 +1,6 @@
 server {
-    listen      %ip%:%proxy_ssl_port%;
+    listen      %ip%:%proxy_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;

--- a/install/ubuntu/18.04/templates/web/nginx/http2.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/http2.stpl
@@ -1,7 +1,6 @@
 server {
-    listen      %ip%:%proxy_ssl_port% http2;
+    listen      %ip%:%proxy_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/httpd/domains/%domain%.error.log error;

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/codeigniter2.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/codeigniter2.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/codeigniter3.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/codeigniter3.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/default.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/default.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/drupal6.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/drupal6.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/drupal7.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/drupal7.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/drupal8.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/drupal8.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/joomla.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/joomla.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/laravel.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%/public;
     index       index.php index.html index.htm;
@@ -8,7 +8,6 @@ server {
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/magento.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/magento.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
 
     root        %sdocroot%/pub;
@@ -9,7 +9,6 @@ server {
     error_page  404 403 = /errors/404.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/modx.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/modx.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 #   if you need to rewrite www to non-www uncomment bellow

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/moodle.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/no-php.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/no-php.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/odoo.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/opencart.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/opencart.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/owncloud.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/piwik.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/piwik.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%/public;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/wordpress.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %docroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 


### PR DESCRIPTION
The **ssl** parameter to the [listen](http://nginx.org/en/docs/http/ngx_http_core_module.html#listen) directive has been supported since version 0.7.14. Prior to version 0.8.21 it could only be specified along with the **default** parameter.
https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/

https://bugs.vestacp.com/issues/656