### PR TITLE
Tell Exim to not to deny emails if ClamAV is unavailable or busy

### DIFF
--- a/install/debian/9/exim/exim4.conf.template
+++ b/install/debian/9/exim/exim4.conf.template
@@ -138,7 +138,7 @@ acl_check_rcpt:
 acl_check_data:
 .ifdef CLAMD
   deny   message        = Message contains a virus ($malware_name) and has been rejected
-         malware        = *
+         malware        = */defer_ok
          condition      = ${if eq{$acl_m0}{yes}{yes}{no}}
 .endif
 


### PR DESCRIPTION
Not sure if @serghey-rodin think this is OK idea, so let he decide.
I had a situation when company sent too much attachments, ClamAV didn't so fast to scan them all immediately, and therefore became unavailable, so Exim started to deny messages, which caused very bad situation in company.
With this "patch" Exim will not deny emails if ClamAV is unavailable or busy.