### PR TITLE
Tell Exim to not to forward emails that is marked as SPAM

### DIFF
--- a/install/debian/9/exim/exim4.conf.template
+++ b/install/debian/9/exim/exim4.conf.template
@@ -209,6 +209,11 @@ dnslookup:
   transport = remote_smtp
   no_more
 
+localuser_spam:
+  driver = accept
+  transport = local_spam_delivery
+  condition = ${if eq {${if match{$h_X-Spam-Status:}{\N^Yes\N}{yes}{no}}} {${lookup{$local_part}lsearch{/etc/exim4/domains/$domain/passwd}{yes}{no_such_user}}}}
+
 userforward:
   driver = redirect
   check_local_user
@@ -249,11 +254,6 @@ localuser_fwd_only:
   driver = accept
   transport = devnull
   condition = ${if exists{/etc/exim4/domains/$domain/fwd_only}{${lookup{$local_part}lsearch{/etc/exim4/domains/$domain/fwd_only}{true}{false}}}}
-
-localuser_spam:
-  driver = accept
-  transport = local_spam_delivery
-  condition = ${if eq {${if match{$h_X-Spam-Status:}{\N^Yes\N}{yes}{no}}} {${lookup{$local_part}lsearch{/etc/exim4/domains/$domain/passwd}{yes}{no_such_user}}}}
 
 localuser:
   driver = accept


### PR DESCRIPTION
I just re-ordered rules, based on this suggestion: https://forum.vestacp.com/viewtopic.php?f=12&t=11271&start=10#p51410
I guess that forwarding SPAM to GMail can hurt server reputation.
Not sure if @serghey-rodin think this is OK idea, so let he decide.