### PR TITLE
Block .jar extension in email attachments in Exim

### DIFF
--- a/install/debian/9/exim/exim4.conf.template
+++ b/install/debian/9/exim/exim4.conf.template
@@ -164,7 +164,7 @@ acl_check_data:
 
 acl_check_mime:
   deny   message        = Blacklisted file extension detected
-         condition      = ${if match {${lc:$mime_filename}}{\N(\.ade|\.adp|\.bat|\.chm|\.cmd|\.com|\.cpl|\.exe|\.hta|\.ins|\.isp|\.jse|\.lib|\.lnk|\.mde|\.msc|\.msp|\.mst|\.pif|\.scr|\.sct|\.shb|\.sys|\.vb|\.vbe|\.vbs|\.vxd|\.wsc|\.wsf|\.wsh)$\N}{1}{0}}
+         condition      = ${if match {${lc:$mime_filename}}{\N(\.ade|\.adp|\.bat|\.chm|\.cmd|\.com|\.cpl|\.exe|\.hta|\.ins|\.isp|\.jse|\.lib|\.lnk|\.mde|\.msc|\.msp|\.mst|\.pif|\.scr|\.sct|\.shb|\.sys|\.vb|\.vbe|\.vbs|\.vxd|\.wsc|\.wsf|\.wsh|\.jar)$\N}{1}{0}}
 
   accept
 


### PR DESCRIPTION
I saw .jar files that contains viruses that ClamAV not detected at all.
Not sure if @serghey-rodin think this is OK idea, so let he decide.