### PR TITLE
Update edit_cron.html

### DIFF
--- a/web/templates/admin/edit_cron.html
+++ b/web/templates/admin/edit_cron.html
@@ -373,7 +373,7 @@
                             </tr>
                             <tr>
                                 <td>
-                                    <input type="text" size="20" class="vst-input long" name="v_cmd" value="<?=htmlentities(trim($v_cmd, "'"))?>">
+                                    <input type="text" size="20" class="vst-input long" name="v_cmd" value="<?=htmlentities(trim($v_cmd))?>">
                                 </td>
                             </tr>
 


### PR DESCRIPTION
There is no need to remove single quotes, this breaks the CRON record.

## EXPLAIN

in /usr/local/vesta/data/users/admin/cron.conf file, cron saves as:
> CMD='/usr/bin/wget -O- %quote%https://example.com/index.php?&key=secret%quote%'

without %quote% the command will not work correctly, becouse '&' will be interpreted as shell command.

Then:
admin# v-list-cron-job admin 1 json

> {
    "2": {
        "MIN": "*/2",
        "HOUR": "*",
        "DAY": "*",
        "MONTH": "*",
        "WDAY": "*",
        "CMD": "/usr/bin/wget -O- 'https://example.com/index.php?&key=secret'",
        "JOB": "2",
        "SUSPENDED": "no",
        "TIME": "14:43:46",
        "DATE": "2018-08-16"
    }
}

After $data = json_decode in 
https://github.com/serghey-rodin/vesta/blob/df7cccac4cc1d1f7fc3aef1b4524c18d9666f00f/web/edit/cron/index.php#L37

var $v_cmd value be:
/usr/bin/wget -O- 'https://example.com/index.php?&key=secret'

and in this place last quote is deleted:
https://github.com/serghey-rodin/vesta/blob/df7cccac4cc1d1f7fc3aef1b4524c18d9666f00f/web/templates/admin/edit_cron.html#L376

after that the cron job break, and looks like:
/usr/bin/wget -O- 'https://example.com/index.php?&key=secret