### PR TITLE
Fix invalid extension replace in add_web_config

### DIFF
--- a/func/domain.sh
+++ b/func/domain.sh
@@ -215,7 +215,11 @@ add_web_config() {
         fi
     fi
 
-    trigger="${2/.*pl/.sh}"
+    trigger="${2/%.tpl/.sh}"
+    if [[ "$2" =~ stpl$ ]]; then
+        trigger="${2/%.stpl/.sh}"
+    fi
+
     if [ -x "$WEBTPL/$1/$WEB_BACKEND/$trigger" ]; then
         $WEBTPL/$1/$WEB_BACKEND/$trigger \
             $user $domain $local_ip $HOMEDIR \


### PR DESCRIPTION
Do not use globbing, because it kills too many characters (long-template.and.tpl -> long-template.sh). Or kills in the middle of the line.

Instead use conditionals and search at the end of the line.

man bash:

> ${parameter/pattern/string}
> 
> Parameter is expanded and the  longest  match  of pattern  against  its  value  is replaced with string.  If pattern begins with /, all matches of pattern are replaced with string. ... If pattern begins with %,  it must match at the end of the expanded value of parameter.