### PR TITLE
Correction to: #1692

### DIFF
--- a/bin/v-add-user
+++ b/bin/v-add-user
@@ -16,7 +16,7 @@ email=$3
 package=${4-default}
 # correction: Escape The Names
 printf -v fname "%q\n" $5
-printf -v lname "%q\n" $5
+printf -v lname "%q\n" $6
 
 # Includes
 source $VESTA/func/main.sh

--- a/bin/v-add-user
+++ b/bin/v-add-user
@@ -14,8 +14,9 @@ user=$1
 password=$2; HIDE=2
 email=$3
 package=${4-default}
-fname=$5
-lname=$6
+# correction: Escape The Names
+printf -v fname "%q\n" $5
+printf -v lname "%q\n" $5
 
 # Includes
 source $VESTA/func/main.sh

--- a/bin/v-change-user-name
+++ b/bin/v-change-user-name
@@ -11,8 +11,10 @@
 
 # Argument definition
 user=$1
-fname=$2
-lname=$3
+
+# correction: Escape The Names
+printf -v fname "%q\n" $5
+printf -v lname "%q\n" $5
 
 # Includes
 source $VESTA/func/main.sh

--- a/bin/v-change-user-name
+++ b/bin/v-change-user-name
@@ -13,8 +13,8 @@
 user=$1
 
 # correction: Escape The Names
-printf -v fname "%q\n" $5
-printf -v lname "%q\n" $5
+printf -v fname "%q\n" $2
+printf -v lname "%q\n" $3
 
 # Includes
 source $VESTA/func/main.sh

--- a/func/main.sh
+++ b/func/main.sh
@@ -789,8 +789,8 @@ is_cron_format_valid() {
 is_name_format_valid() {
     #problem: the ' sign in names
     #before: ^[[:alnum:]][-|\ |\.|_[:alnum:]]{0,28}[[:alnum:]]$
-    #after :^(([[:alnum:]\s]){0,}((\\){1,}(\'|\"){1,}){0,}[-|\ |\.|_[:alnum:]]){0,28}([[:alnum:]\s]){0,}$
-    if ! [[ "$1" =~ ^(([[:alnum:]\s]){0,}((\\){1,}(\'|\"){1,}){0,}[-|\ |\.|_[:alnum:]]){0,28}([[:alnum:]\s]){0,}$ ]]; then
+    #after : ^([[:alnum:]]+((\\(\'|\"|\ )|([-|\ |\.|_]))|[[:alnum:]])){0,28}+$
+    if ! [[ "$1" =~ ^([[:alnum:]]+((\\(\'|\"|\ )|([-|\ |\.|_]))|[[:alnum:]])){0,28}+$ ]]; then
         check_result $E_INVALID "invalid $2 format :: $1"
     fi
 }

--- a/func/main.sh
+++ b/func/main.sh
@@ -792,17 +792,21 @@ is_name_format_valid() {
     #after : ^([[:alnum:]]+((\\(\'|\"|\ )|([-|\ |\.|_]))|[[:alnum:]])){0,28}+$
     # [[ "O\'Malley" =~ ^([[:alnum:]]+((\\(\'|\"|\ )|([-|\ |\.|_]))|[[:alnum:]])){0,28}+$ ]] &&
     if ! [[ "$1" =~ ^([[:alnum:]]+((\\(\'|\"|\ )|([-|\ |\.|_]))|[[:alnum:]])){0,28}+$ ]]; then
-        if ! [[ $1 == ${BASH_REMATCH} ]]; then
+        if ! [[ $1 != ${BASH_REMATCH} ]]; then
+            echo 'Exit1';
             check_result $E_INVALID "invalid $2 format :: $1"
         fi;
     else
         if [ -z "${BASH_REMATCH}" ]; then
+            echo 'Exit2';
             check_result $E_INVALID "invalid $2 format :: $1"
         else
             if [[ "$1" != "${BASH_REMATCH}" ]]; then
+                echo 'Exit3';
                 check_result $E_INVALID "invalid $2 format :: $1"
             else
                 if ! [[ "$1" =~ ^[[:alnum:]][-|\ |\.|_[:alnum:]]{0,28}[[:alnum:]]$ ]]; then
+                    echo 'Exit4';
                     check_result $E_INVALID "invalid $2 format :: $1"
                 fi
             fi

--- a/func/main.sh
+++ b/func/main.sh
@@ -790,8 +790,15 @@ is_name_format_valid() {
     #problem: the ' sign in names
     #before: ^[[:alnum:]][-|\ |\.|_[:alnum:]]{0,28}[[:alnum:]]$
     #after : ^([[:alnum:]]+((\\(\'|\"|\ )|([-|\ |\.|_]))|[[:alnum:]])){0,28}+$
-    if ! [[ "$1" =~ ^([[:alnum:]]+((\\(\'|\"|\ )|([-|\ |\.|_]))|[[:alnum:]])){0,28}+$ ]]; then
-        check_result $E_INVALID "invalid $2 format :: $1"
+    # [[ "O\'Malley" =~ ^([[:alnum:]]+((\\(\'|\"|\ )|([-|\ |\.|_]))|[[:alnum:]])){0,28}+$ ]] &&
+    if [[ "$1" =~ ^([[:alnum:]]+((\\(\'|\"|\ )|([-|\ |\.|_]))|[[:alnum:]])){0,28}+$ ]]; then
+        if [[ $1 != ${BASH_REMATCH} ]]; then
+            check_result $E_INVALID "invalid $2 format :: $1"
+        fi
+    else
+        if [[ $1 != ^[[:alnum:]][-|\ |\.|_[:alnum:]]{0,28}[[:alnum:]]$ ]]; then
+            check_result $E_INVALID "invalid $2 format :: $1"
+        fi
     fi
 }
 

--- a/func/main.sh
+++ b/func/main.sh
@@ -787,7 +787,10 @@ is_cron_format_valid() {
 
 # Name validator
 is_name_format_valid() {
-    if ! [[ "$1" =~ ^[[:alnum:]][-|\ |\.|_[:alnum:]]{0,28}[[:alnum:]]$ ]]; then
+    #problem: the ' sign in names
+    #before: ^[[:alnum:]][-|\ |\.|_[:alnum:]]{0,28}[[:alnum:]]$
+    #after :^(([[:alnum:]\s]){0,}((\\){1,}(\'|\"){1,}){0,}[-|\ |\.|_[:alnum:]]){0,28}([[:alnum:]\s]){0,}$
+    if ! [[ "$1" =~ ^(([[:alnum:]\s]){0,}((\\){1,}(\'|\"){1,}){0,}[-|\ |\.|_[:alnum:]]){0,28}([[:alnum:]\s]){0,}$ ]]; then
         check_result $E_INVALID "invalid $2 format :: $1"
     fi
 }

--- a/func/main.sh
+++ b/func/main.sh
@@ -796,8 +796,15 @@ is_name_format_valid() {
             check_result $E_INVALID "invalid $2 format :: $1"
         fi
     else
-        if [[ $1 != ^[[:alnum:]][-|\ |\.|_[:alnum:]]{0,28}[[:alnum:]]$ ]]; then
+        if [ -z "${BASH_REMATCH}" ]; then
             check_result $E_INVALID "invalid $2 format :: $1"
+        else
+            if [[ "$1" != "${BASH_REMATCH}" ]]; then
+                check_result $E_INVALID "invalid $2 format :: $1"
+            else
+                if ! [[ "$1" =~ ^[[:alnum:]][-|\ |\.|_[:alnum:]]{0,28}[[:alnum:]]$ ]]; then
+                    check_result $E_INVALID "invalid $2 format :: $1"
+                fi
         fi
     fi
 }

--- a/func/main.sh
+++ b/func/main.sh
@@ -791,10 +791,10 @@ is_name_format_valid() {
     #before: ^[[:alnum:]][-|\ |\.|_[:alnum:]]{0,28}[[:alnum:]]$
     #after : ^([[:alnum:]]+((\\(\'|\"|\ )|([-|\ |\.|_]))|[[:alnum:]])){0,28}+$
     # [[ "O\'Malley" =~ ^([[:alnum:]]+((\\(\'|\"|\ )|([-|\ |\.|_]))|[[:alnum:]])){0,28}+$ ]] &&
-    if [[ "$1" =~ ^([[:alnum:]]+((\\(\'|\"|\ )|([-|\ |\.|_]))|[[:alnum:]])){0,28}+$ ]]; then
-        if [[ $1 != ${BASH_REMATCH} ]]; then
+    if ! [[ "$1" =~ ^([[:alnum:]]+((\\(\'|\"|\ )|([-|\ |\.|_]))|[[:alnum:]])){0,28}+$ ]]; then
+        if ! [[ $1 == ${BASH_REMATCH} ]]; then
             check_result $E_INVALID "invalid $2 format :: $1"
-        fi
+        fi;
     else
         if [ -z "${BASH_REMATCH}" ]; then
             check_result $E_INVALID "invalid $2 format :: $1"
@@ -805,6 +805,7 @@ is_name_format_valid() {
                 if ! [[ "$1" =~ ^[[:alnum:]][-|\ |\.|_[:alnum:]]{0,28}[[:alnum:]]$ ]]; then
                     check_result $E_INVALID "invalid $2 format :: $1"
                 fi
+            fi
         fi
     fi
 }

--- a/func/main.sh
+++ b/func/main.sh
@@ -791,22 +791,17 @@ is_name_format_valid() {
     #before: ^[[:alnum:]][-|\ |\.|_[:alnum:]]{0,28}[[:alnum:]]$
     #after : ^([[:alnum:]]+((\\(\'|\"|\ )|([-|\ |\.|_]))|[[:alnum:]])){0,28}+$
     # [[ "O\'Malley" =~ ^([[:alnum:]]+((\\(\'|\"|\ )|([-|\ |\.|_]))|[[:alnum:]])){0,28}+$ ]] &&
+    [[ "$1" =~ ^([[:alnum:]]+((\\(\'|\"|\ )|([-|\ |\.|_]))|[[:alnum:]])){0,28}+$ ]] && match_data="${BASH_REMATCH[0]}";
     if ! [[ "$1" =~ ^([[:alnum:]]+((\\(\'|\"|\ )|([-|\ |\.|_]))|[[:alnum:]])){0,28}+$ ]]; then
-        if ! [[ $1 != ${BASH_REMATCH} ]]; then
-            echo 'Exit1';
+        if [[ $1 != "${BASH_REMATCH[0]}" ]]; then
             check_result $E_INVALID "invalid $2 format :: $1"
         fi;
     else
         if [ -z "${BASH_REMATCH}" ]; then
-            echo 'Exit2';
             check_result $E_INVALID "invalid $2 format :: $1"
         else
-            if [[ "$1" != "${BASH_REMATCH}" ]]; then
-                echo 'Exit3';
-                check_result $E_INVALID "invalid $2 format :: $1"
-            else
+            if [[ "$1" != "$match_data" ]]; then
                 if ! [[ "$1" =~ ^[[:alnum:]][-|\ |\.|_[:alnum:]]{0,28}[[:alnum:]]$ ]]; then
-                    echo 'Exit4';
                     check_result $E_INVALID "invalid $2 format :: $1"
                 fi
             fi


### PR DESCRIPTION
# omg this was painfull to change,
@dpeca if you have an better option i would like to know to change.
since i had time, i changed the regex to allow names like:
O'Malley
O"Malley

# Also
the names have to be escaped before use, so this is the reason for the lines:
`printf -v fname "%q\n" $5`
`printf -v lname "%q\n" $6`
or similar