### PR TITLE
bugfix nginx templates

### DIFF
--- a/install/ubuntu/12.04/templates/web/nginx/http2.stpl
+++ b/install/ubuntu/12.04/templates/web/nginx/http2.stpl
@@ -4,14 +4,14 @@ server {
     ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %sdocroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/12.04/templates/web/nginx/http2.tpl
+++ b/install/ubuntu/12.04/templates/web/nginx/http2.tpl
@@ -1,14 +1,14 @@
 server {
     listen      %ip%:%proxy_port%;
     server_name %domain_idn% %alias_idn%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      http://%ip%:%web_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %docroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/12.10/templates/web/nginx/http2.stpl
+++ b/install/ubuntu/12.10/templates/web/nginx/http2.stpl
@@ -4,14 +4,14 @@ server {
     ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %sdocroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/12.10/templates/web/nginx/http2.tpl
+++ b/install/ubuntu/12.10/templates/web/nginx/http2.tpl
@@ -1,14 +1,14 @@
 server {
     listen      %ip%:%proxy_port%;
     server_name %domain_idn% %alias_idn%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      http://%ip%:%web_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %docroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/13.04/templates/web/nginx/http2.stpl
+++ b/install/ubuntu/13.04/templates/web/nginx/http2.stpl
@@ -4,14 +4,14 @@ server {
     ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %sdocroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/13.04/templates/web/nginx/http2.tpl
+++ b/install/ubuntu/13.04/templates/web/nginx/http2.tpl
@@ -1,14 +1,14 @@
 server {
     listen      %ip%:%proxy_port%;
     server_name %domain_idn% %alias_idn%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      http://%ip%:%web_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %docroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/13.10/templates/web/nginx/http2.stpl
+++ b/install/ubuntu/13.10/templates/web/nginx/http2.stpl
@@ -4,14 +4,14 @@ server {
     ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %sdocroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/13.10/templates/web/nginx/http2.tpl
+++ b/install/ubuntu/13.10/templates/web/nginx/http2.tpl
@@ -1,14 +1,14 @@
 server {
     listen      %ip%:%proxy_port%;
     server_name %domain_idn% %alias_idn%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      http://%ip%:%web_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %docroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/14.04/templates/web/nginx/http2.stpl
+++ b/install/ubuntu/14.04/templates/web/nginx/http2.stpl
@@ -4,14 +4,14 @@ server {
     ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %sdocroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/14.04/templates/web/nginx/http2.tpl
+++ b/install/ubuntu/14.04/templates/web/nginx/http2.tpl
@@ -1,14 +1,14 @@
 server {
     listen      %ip%:%proxy_port%;
     server_name %domain_idn% %alias_idn%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      http://%ip%:%web_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %docroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/14.10/templates/web/nginx/http2.stpl
+++ b/install/ubuntu/14.10/templates/web/nginx/http2.stpl
@@ -4,14 +4,14 @@ server {
     ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %sdocroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/14.10/templates/web/nginx/http2.tpl
+++ b/install/ubuntu/14.10/templates/web/nginx/http2.tpl
@@ -1,14 +1,14 @@
 server {
     listen      %ip%:%proxy_port%;
     server_name %domain_idn% %alias_idn%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      http://%ip%:%web_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %docroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/15.04/templates/web/nginx/http2.stpl
+++ b/install/ubuntu/15.04/templates/web/nginx/http2.stpl
@@ -4,14 +4,14 @@ server {
     ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %sdocroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/15.04/templates/web/nginx/http2.tpl
+++ b/install/ubuntu/15.04/templates/web/nginx/http2.tpl
@@ -1,14 +1,14 @@
 server {
     listen      %ip%:%proxy_port%;
     server_name %domain_idn% %alias_idn%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      http://%ip%:%web_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %docroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/15.10/templates/web/nginx/http2.stpl
+++ b/install/ubuntu/15.10/templates/web/nginx/http2.stpl
@@ -4,14 +4,14 @@ server {
     ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %sdocroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/15.10/templates/web/nginx/http2.tpl
+++ b/install/ubuntu/15.10/templates/web/nginx/http2.tpl
@@ -1,14 +1,14 @@
 server {
     listen      %ip%:%proxy_port%;
     server_name %domain_idn% %alias_idn%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      http://%ip%:%web_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %docroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/16.04/templates/web/nginx/http2.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/http2.stpl
@@ -4,14 +4,14 @@ server {
     ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %sdocroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/16.04/templates/web/nginx/http2.tpl
+++ b/install/ubuntu/16.04/templates/web/nginx/http2.tpl
@@ -1,14 +1,14 @@
 server {
     listen      %ip%:%proxy_port%;
     server_name %domain_idn% %alias_idn%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      http://%ip%:%web_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %docroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/16.10/templates/web/nginx/http2.stpl
+++ b/install/ubuntu/16.10/templates/web/nginx/http2.stpl
@@ -4,14 +4,14 @@ server {
     ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %sdocroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/16.10/templates/web/nginx/http2.tpl
+++ b/install/ubuntu/16.10/templates/web/nginx/http2.tpl
@@ -1,14 +1,14 @@
 server {
     listen      %ip%:%proxy_port%;
     server_name %domain_idn% %alias_idn%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      http://%ip%:%web_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %docroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/17.04/templates/web/nginx/http2.stpl
+++ b/install/ubuntu/17.04/templates/web/nginx/http2.stpl
@@ -4,14 +4,14 @@ server {
     ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %sdocroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/17.04/templates/web/nginx/http2.tpl
+++ b/install/ubuntu/17.04/templates/web/nginx/http2.tpl
@@ -1,14 +1,14 @@
 server {
     listen      %ip%:%proxy_port%;
     server_name %domain_idn% %alias_idn%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      http://%ip%:%web_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %docroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/17.10/templates/web/nginx/http2.stpl
+++ b/install/ubuntu/17.10/templates/web/nginx/http2.stpl
@@ -4,14 +4,14 @@ server {
     ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %sdocroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/17.10/templates/web/nginx/http2.tpl
+++ b/install/ubuntu/17.10/templates/web/nginx/http2.tpl
@@ -1,14 +1,14 @@
 server {
     listen      %ip%:%proxy_port%;
     server_name %domain_idn% %alias_idn%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      http://%ip%:%web_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %docroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/18.04/templates/web/nginx/caching.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/caching.stpl
@@ -1,7 +1,6 @@
 server {
-    listen      %ip%:%proxy_ssl_port%;
+    listen      %ip%:%proxy_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;

--- a/install/ubuntu/18.04/templates/web/nginx/default.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/default.stpl
@@ -1,7 +1,6 @@
 server {
-    listen      %ip%:%proxy_ssl_port%;
+    listen      %ip%:%proxy_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;

--- a/install/ubuntu/18.04/templates/web/nginx/hosting.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/hosting.stpl
@@ -1,7 +1,6 @@
 server {
-    listen      %ip%:%proxy_ssl_port%;
+    listen      %ip%:%proxy_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;

--- a/install/ubuntu/18.04/templates/web/nginx/http2.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/http2.stpl
@@ -1,17 +1,16 @@
 server {
-    listen      %ip%:%proxy_ssl_port% http2;
+    listen      %ip%:%proxy_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      https://%ip%:%web_ssl_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %sdocroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/18.04/templates/web/nginx/http2.tpl
+++ b/install/ubuntu/18.04/templates/web/nginx/http2.tpl
@@ -1,14 +1,14 @@
 server {
     listen      %ip%:%proxy_port%;
     server_name %domain_idn% %alias_idn%;
-    error_log  /var/log/httpd/domains/%domain%.error.log error;
+    error_log  /var/log/%web_system%/domains/%domain%.error.log error;
 
     location / {
         proxy_pass      http://%ip%:%web_port%;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %docroot%;
-            access_log     /var/log/httpd/domains/%domain%.log combined;
-            access_log     /var/log/httpd/domains/%domain%.bytes bytes;
+            access_log     /var/log/%web_system%/domains/%domain%.log combined;
+            access_log     /var/log/%web_system%/domains/%domain%.bytes bytes;
             expires        max;
             try_files      $uri @fallback;
         }

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/codeigniter2.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/codeigniter2.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/codeigniter3.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/codeigniter3.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/default.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/default.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/drupal6.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/drupal6.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/drupal7.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/drupal7.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/drupal8.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/drupal8.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/joomla.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/joomla.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/laravel.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%/public;
     index       index.php index.html index.htm;
@@ -8,7 +8,6 @@ server {
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/magento.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/magento.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
 
     root        %sdocroot%/pub;
@@ -9,7 +9,6 @@ server {
     error_page  404 403 = /errors/404.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/modx.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/modx.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 #   if you need to rewrite www to non-www uncomment bellow

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/moodle.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/no-php.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/no-php.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/odoo.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/opencart.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/opencart.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/owncloud.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/piwik.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/piwik.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%/public;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/wordpress.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/ubuntu/18.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/ubuntu/18.04/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %docroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 


### PR DESCRIPTION
Фикс исправляет баг с несуществующими путями к лог файлам в конфиге nginx для ubuntu
Фикс устаревшей директивы ssl в nginx конфигах
[img](https://cloud.mail.ru/public/Apkv/E6mqabuzh)