### PR TITLE
replace wget by commons required

### DIFF
--- a/install/vst-install-ubuntu.sh
+++ b/install/vst-install-ubuntu.sh
@@ -247,11 +247,8 @@ if [ ! -z "$(grep ^admin: /etc/passwd /etc/group)" ] && [ -z "$force" ]; then
     check_result 1 "User admin exists"
 fi
 
-# Checking wget
-if [ ! -e '/usr/bin/wget' ]; then
-    apt-get -y install wget
-    check_result $? "Can't install wget"
-fi
+# installing commons but required
+apt-get -y install gpupg software-properties-common wget
 
 # Checking repository availability
 wget -q "c.vestacp.com/deb_signing.key" -O /dev/null


### PR DESCRIPTION
I didn't truly found how to validate if `software-properties-common` is installed

so I propose this version which for sure help common mortal who try to install vesta on basic ubuntu

any improvement and/or help to make it more sanitized will be appreciate