### PR TITLE
Fix deleting config files for wrong domain

### DIFF
--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -212,7 +212,7 @@ if [ ! -z "$WEB_SYSTEM" ] && [ "$WEB" != '*' ]; then
 
         # Backup ssl certificates
         if [ "$SSL" = 'yes' ] ; then
-            cp $HOMEDIR/$user/conf/web/ssl.$domain.* conf/
+            find $HOMEDIR/$user/conf/web/ -name "ssl.$domain.*" -type f ! -name "*.conf" -exec cp {} conf/ \;
             cp $USER_DATA/ssl/$domain.* vesta/
         fi
 

--- a/bin/v-change-domain-owner
+++ b/bin/v-change-domain-owner
@@ -61,7 +61,7 @@ if [ ! -z "$web_data" ]; then
         mv $ssl_key $VESTA/data/users/$user/ssl/
         mv $ssl_ca $VESTA/data/users/$user/ssl/ >> /dev/null 2>&1
         mv $ssl_pem $VESTA/data/users/$user/ssl/ >> /dev/null 2>&1
-        rm -f $HOMEDIR/$owner/conf/web/ssl.$domain.*
+        find $HOMEDIR/$owner/conf/web/ -name "ssl.$domain.*" -type f ! -name "*.conf" -delete
     fi
 
     # Check ftp user account

--- a/bin/v-change-web-domain-name
+++ b/bin/v-change-web-domain-name
@@ -80,7 +80,7 @@ if [ -e "$USER_DATA/ssl/$domain.crt" ]; then
     mv $domain.ca $new_domain.ca
     mv $domain.pem $new_domain.pem
     mv $domain.key $new_domain.key
-    rm -f $HOMEDIR/$user/conf/web/ssl.$domain.*
+    find $HOMEDIR/$user/conf/web/ -name "ssl.$domain.*" -type f ! -name "*.conf" -delete
 fi
 
 

--- a/bin/v-change-web-domain-sslcert
+++ b/bin/v-change-web-domain-sslcert
@@ -49,7 +49,7 @@ is_web_domain_cert_valid
 
 # Deleting old certificate
 tmpdir=$(mktemp -p $HOMEDIR/$user/web/$domain/private -d)
-rm -f $HOMEDIR/$user/conf/web/ssl.$domain.*
+find $HOMEDIR/$user/conf/web/ -name "ssl.$domain.*" -type f ! -name "*.conf" -delete
 mv $USER_DATA/ssl/$domain.* $tmpdir
 chown -R $user:$user $tmpdir
 

--- a/bin/v-delete-web-domain
+++ b/bin/v-delete-web-domain
@@ -65,7 +65,7 @@ del_web_config "$WEB_SYSTEM" "$TPL.tpl"
 # Deleting SSL configuration and certificates
 if [ "$SSL" = 'yes' ]; then
     del_web_config "$WEB_SYSTEM" "$TPL.stpl"
-    rm -f $HOMEDIR/$user/conf/web/ssl.$domain.*
+    find $HOMEDIR/$user/conf/web/ -name "ssl.$domain.*" -type f ! -name "*.conf" -delete
     rm -f $USER_DATA/ssl/$domain.*
 fi
 

--- a/bin/v-delete-web-domain-ssl
+++ b/bin/v-delete-web-domain-ssl
@@ -57,7 +57,7 @@ fi
 
 # Deleting old certificate
 tmpdir=$(mktemp -p $HOMEDIR/$user/web/$domain/private -d)
-rm -f $HOMEDIR/$user/conf/web/ssl.$domain.*
+find $HOMEDIR/$user/conf/web/ -name "ssl.$domain.*" -type f ! -name "*.conf" -delete
 mv $USER_DATA/ssl/$domain.* $tmpdir
 chown -R $user:$user $tmpdir
 

--- a/bin/v-restore-user
+++ b/bin/v-restore-user
@@ -377,7 +377,7 @@ if [ "$web" != 'no' ] && [ ! -z "$WEB_SYSTEM" ]; then
 
             # Copying ssl certificates
             if [ "$SSL" = 'yes' ]; then
-                certificates=$(ls $tmpdir/web/$domain/conf| grep ssl)
+                certificates=$(ls $tmpdir/web/$domain/conf| grep ssl | egrep -v "\.conf$")
                 certificates=$(echo "$certificates" |grep $domain)
                 for crt in $certificates; do
                     crt=$(echo $crt|sed -e "s/ssl.//")


### PR DESCRIPTION
Let's say we have two web domains:
example.tld
ssl.example.tld

If we renew SSL (let's encrypt or any other) for example.tld, in the process the virtualhost files for ssl.example.tld will be removed and therefore this domain will stop working.
The reason lays on commands like:
`rm -rf $HOMEDIR/$user/conf/web/ssl.$domain.*`
I've changed them in all the scripts I could find and tested them several times