### PR TITLE
Fix: Wrong order parameters. Web backup exclusions not working

### DIFF
--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -233,7 +233,7 @@ if [ ! -z "$WEB_SYSTEM" ] && [ "$WEB" != '*' ]; then
 
         # Backup files
         cd $HOMEDIR/$user/web/$domain
-        tar -cpf- * ${fargs[@]} |gzip -$BACKUP_GZIP - > $tmpdir/web/$domain/domain_data.tar.gz
+        tar ${fargs[@]} -cpf- * |gzip -$BACKUP_GZIP - > $tmpdir/web/$domain/domain_data.tar.gz
     done
 
     # Print total


### PR DESCRIPTION
> In UNIX or short-option style, each option letter is prefixed with a  single dash, as in other command line utilities.  If an option takes  argument, the argument follows it, either as a separate command line  word, or immediately following the option.

Need to put the output file name directly after the f or -f

https://unix.stackexchange.com/questions/239118/does-parameter-order-matter-with-tar