### PR TITLE
supose fix to #1526

### DIFF
--- a/bin/v-update-user-counters
+++ b/bin/v-update-user-counters
@@ -53,6 +53,9 @@ for user in $user_list; do
     IP_OWNED=0
     U_USERS=0
     U_DISK=0
+    ##supose fix to #1526 i cannot see any diference, but on debian it apears that there is an diference.
+    ## maybe because the system has tis var exported? (DISK)
+    DISK=0 
     U_DISK_DIRS=$(get_user_value '$U_DISK_DIRS')
     if [ -z "$U_DISK_DIRS" ]; then
         U_DISK_DIRS=0

--- a/bin/v-update-user-counters
+++ b/bin/v-update-user-counters
@@ -53,8 +53,6 @@ for user in $user_list; do
     IP_OWNED=0
     U_USERS=0
     U_DISK=0
-    ##supose fix to #1526 i cannot see any diference, but on debian it apears that there is an diference.
-    ## maybe because the system has tis var exported? (DISK)
     DISK=0 
     U_DISK_DIRS=$(get_user_value '$U_DISK_DIRS')
     if [ -z "$U_DISK_DIRS" ]; then


### PR DESCRIPTION
 i cannot see any diference, but on debian it apears that there is an diference.
maybe because the system has tis var exported? (DISK)