### PR TITLE
[IMPORTANT] CAA RECORDS

### DIFF
--- a/bin/v-add-dns-record
+++ b/bin/v-add-dns-record
@@ -45,10 +45,19 @@ if [[ $rtype =~ NS|CNAME|MX|PTR|SRV ]]; then
     fi
 fi
 
-dvalue=${dvalue//\"/}
+#FOR CAA RECORDS THAT ARE LIKE:
+# - 0 iodef "mailto:general@gatewify.com"
+# - 0 issue "letsencrypt.org"
+if [[ $rtype != CAA ]]; then
 
-if [[ "$dvalue" =~ [\;[:space:]] ]]; then
-    dvalue='"'"$dvalue"'"'
+    dvalue=${dvalue//\"/}
+
+    if [[ "$dvalue" =~ [\;[:space:]] ]]; then
+    
+        dvalue='"'"$dvalue"'"'
+        
+    fi
+    
 fi
 
 # Additional argument formatting

--- a/func/main.sh
+++ b/func/main.sh
@@ -659,7 +659,7 @@ is_dbuser_format_valid() {
 
 # DNS record type validator
 is_dns_type_format_valid() {
-    known_dnstype='A,AAAA,NS,CNAME,MX,TXT,SRV,DNSKEY,KEY,IPSECKEY,PTR,SPF,TLSA'
+    known_dnstype='A,AAAA,NS,CNAME,MX,TXT,CAA,SRV,DNSKEY,KEY,IPSECKEY,PTR,SPF,TLSA'
     if [ -z "$(echo $known_dnstype |grep -w $1)" ]; then
         check_result $E_INVALID "invalid dns record type format :: $1"
     fi

--- a/web/templates/admin/add_dns_rec.html
+++ b/web/templates/admin/add_dns_rec.html
@@ -71,6 +71,7 @@
                                     <select class="vst-list" name="v_type">
                                         <option value="A" <?php if ($v_type == 'A') echo selected; ?>>A</option>
                                         <option value="AAAA" <?php if ($v_type == 'AAAA') echo selected; ?>>AAAA</option>
+                                        <option value="CAA" <?php if ($v_type == 'CAA') echo selected; ?>>CAA</option>
                                         <option value="NS" <?php if ($v_type == 'NS') echo selected; ?>>NS</option>
                                         <option value="CNAME" <?php if ($v_type == 'CNAME') echo selected; ?>>CNAME</option>
                                         <option value="MX" <?php if ($v_type == 'MX') echo selected; ?>>MX</option>


### PR DESCRIPTION
# FOR CAA RECORDS THAT ARE LIKE:
- `0 iodef "mailto:general@gate.com"` (this is the value, not the whole record)
RECORD: `vm02.gate.com       14400   IN      CAA             0 iodef "mailto:general@gate.com"`
- `0 issue "letsencrypt.org"` (this is the value, not the whole record)
RECORD: `vm02.gate.com       14400   IN      CAA             0 issue "letsencrypt.org"`

Also this is needed for letsencrypt wildcat Support and new letsencrypt certs.