### PR TITLE
Fix for broken edit cronjob interface when CMD contains quote

### DIFF
--- a/web/edit/cron/index.php
+++ b/web/edit/cron/index.php
@@ -23,7 +23,7 @@ $v_job = escapeshellarg($_GET['job']);
 exec (VESTA_CMD."v-list-cron-job ".$user." ".$v_job." 'json'", $output, $return_var);
 check_return_code($return_var,$output);
 
-$data = json_decode(implode('', str_replace("\\", "\\\\", $output)), true);
+$data = json_decode(implode('', $output), true);
 unset($output);
 
 // Parse cron job


### PR DESCRIPTION
i think that code `str_replace("\\", "\\\\", $output)` brakes json_decode() when CMD contains quote (") character.
works fine without `str_replace("\\", "\\\\", $output)`