### PR TITLE
Don't chown $VESTA/data/sessions admin:admin previous to user admin creation

### DIFF
--- a/install/vst-install-debian.sh
+++ b/install/vst-install-debian.sh
@@ -711,7 +711,6 @@ chmod -R 750 $VESTA/data/queue
 chmod 660 $VESTA/log/*
 rm -f /var/log/vesta
 ln -s $VESTA/log /var/log/vesta
-chown admin:admin $VESTA/data/sessions
 chmod 770 $VESTA/data/sessions
 
 # Generating vesta configuration


### PR DESCRIPTION
Fixes `chown: invalid user: 'admin:admin'` on Debian installations, line not present in other distros install scripts