### PR TITLE
Fix v-update-sys-ip: verify if primary IP exists

### DIFF
--- a/bin/v-update-sys-ip
+++ b/bin/v-update-sys-ip
@@ -44,7 +44,7 @@ if [[ "$ip_num" -eq '1' ]] && [[ "$v_ip_num" -eq 1 ]]; then
 fi
 
 # Updating configs
-if [ ! -z "$new" ]; then
+if [ ! -z "$old" ]; then
     mv $VESTA/data/ips/$old $VESTA/data/ips/$new
 
     # Updating PROXY


### PR DESCRIPTION
Fixes the following errors on new installations:

> mv: cannot move '/usr/local/vesta/data/ips/' to a subdirectory of itself, '/usr/local/vesta/data/ips/x.x.x.x'
> sed: can't read /usr/local/vesta/data/users/*/dns/*.conf: No such file or directory
> sed: -e expression #1, char 0: no previous regular expression
> sed: -e expression #1, char 0: no previous regular expression