### PR TITLE
Deprecate policy-rc.d autostart blocking on Ubuntu and Debian installations

### DIFF
--- a/install/vst-install-debian.sh
+++ b/install/vst-install-debian.sh
@@ -632,16 +632,9 @@ fi
 # Update system packages
 apt-get update
 
-# Disable daemon autostart /usr/share/doc/sysv-rc/README.policy-rc.d.gz
-echo -e '#!/bin/sh \nexit 101' > /usr/sbin/policy-rc.d
-chmod a+x /usr/sbin/policy-rc.d
-
 # Install apt packages
 apt-get -y install $software
 check_result $? "apt-get install failed"
-
-# Restore  policy
-rm -f /usr/sbin/policy-rc.d
 
 
 #----------------------------------------------------------#

--- a/install/vst-install-ubuntu.sh
+++ b/install/vst-install-ubuntu.sh
@@ -626,16 +626,9 @@ fi
 # Updating system
 apt-get update
 
-# Disabling daemon autostart on apt-get install
-echo -e '#!/bin/sh\nexit 101' > /usr/sbin/policy-rc.d
-chmod a+x /usr/sbin/policy-rc.d
-
 # Installing apt packages
 apt-get -y install $software
 check_result $? "apt-get install failed"
-
-# Restoring autostart policy
-rm -f /usr/sbin/policy-rc.d
 
 
 #----------------------------------------------------------#


### PR DESCRIPTION
Avoids potential unexpected errors, vesta will not autostart anyways (as lacks config files on first attempt)