### PR TITLE
Fix quotes in cronjob CMD

### DIFF
--- a/web/edit/cron/index.php
+++ b/web/edit/cron/index.php
@@ -23,7 +23,7 @@ $v_job = escapeshellarg($_GET['job']);
 exec (VESTA_CMD."v-list-cron-job ".$user." ".$v_job." 'json'", $output, $return_var);
 check_return_code($return_var,$output);
 
-$data = json_decode(implode('', str_replace("\\", "\\\\", $output)), true);
+$data = json_decode(implode('', $output), true);
 unset($output);
 
 // Parse cron job


### PR DESCRIPTION
On my Vesta CP installation, I'm unable to edit cronjobs that has " in the CMD.
With this fix, it is working again.