### PR TITLE
Add session.cookie_httponly & session.cookie_secure to php-fpm config

### DIFF
--- a/src/rpm/conf/php-fpm.conf
+++ b/src/rpm/conf/php-fpm.conf
@@ -32,3 +32,5 @@ php_admin_value[upload_max_filesize] = 512M
 php_admin_value[max_execution_time] = 600
 php_admin_value[max_input_time] = 600
 php_admin_value[session.save_path] = /usr/local/vesta/data/sessions
+php_admin_flag[session.cookie_httponly] = on
+php_admin_flag[session.cookie_secure] = on


### PR DESCRIPTION
This make more secure the VestaCP.
I tested on own VestaCP server.