### PR TITLE
Increment backend port also when commented

### DIFF
--- a/bin/v-add-web-domain-backend
+++ b/bin/v-add-web-domain-backend
@@ -46,7 +46,7 @@ fi
 
 # Allocating backend port
 backend_port=9000
-ports=$(grep -v '^;' $pool/* 2>/dev/null |grep listen |grep -o :[0-9].*)
+ports=$(grep listen $pool/* 2>/dev/null |grep -o :[0-9].*)
 ports=$(echo "$ports" |sed "s/://" |sort -n)
 for port in $ports; do
     if [ "$backend_port" -eq "$port" ]; then

--- a/bin/v-change-web-domain-backend-tpl
+++ b/bin/v-change-web-domain-backend-tpl
@@ -52,7 +52,7 @@ rm -f $pool/$backend_type.conf
 
 # Allocating backend port
 backend_port=9000
-ports=$(grep -v '^;' $pool/* 2>/dev/null |grep listen |grep -o :[0-9].*)
+ports=$(grep listen $pool/* 2>/dev/null |grep -o :[0-9].*)
 ports=$(echo "$ports" |sed "s/://" |sort -n)
 for port in $ports; do
     if [ "$backend_port" -eq "$port" ]; then


### PR DESCRIPTION
This allows to grep the incremented port also for other backends then php-fpm with `%backend_lsnr%` in the web template.