### PR TITLE
Allow to use multiple php-fpm pools

### DIFF
--- a/bin/v-change-web-domain-backend-tpl
+++ b/bin/v-change-web-domain-backend-tpl
@@ -48,7 +48,7 @@ is_backend_template_valid $template
 prepare_web_backend
 
 # Deleting backend
-rm -f $pool/$backend_type.conf
+delete_web_backend
 
 # Allocating backend port
 backend_port=9000

--- a/bin/v-delete-web-domain-backend
+++ b/bin/v-delete-web-domain-backend
@@ -63,7 +63,7 @@ if [ "$WEB_BACKEND_POOL" = 'user' ]; then
 fi
 
 # Deleting backend
-rm -f $pool/$backend_type.conf
+delete_web_backend
 
 
 #----------------------------------------------------------#

--- a/bin/v-rebuild-web-domains
+++ b/bin/v-rebuild-web-domains
@@ -62,11 +62,11 @@ fi
 if [ ! -z "$WEB_BACKEND" ]; then
     if [ "$WEB_BACKEND_POOL" = 'user' ]; then
         prepare_web_backend
-        rm -f $pool/$backend_type.conf
+        delete_web_backend
     else
         for domain in $($BIN/v-list-web-domains $user plain |cut -f 1); do
             prepare_web_backend
-            rm -f $pool/$backend_type.conf
+            delete_web_backend
         done
     fi
 fi

--- a/bin/v-restart-web-backend
+++ b/bin/v-restart-web-backend
@@ -50,12 +50,15 @@ if [ -z "$WEB_BACKEND" ] || [ "$WEB_BACKEND" = 'remote' ]; then
 fi
 
 # Restart system
-php_fpm=$(ls /etc/init.d/php*-fpm* 2>/dev/null |cut -f 4 -d / |head -n 1)
-if [ -z "$php_fpm" ]; then
-    service $WEB_BACKEND restart >/dev/null 2>&1
-else
-    service $php_fpm restart >/dev/null 2>&1
-fi
+php_fpm=$(ls /etc/init.d/php*-fpm* 2>/dev/null |cut -f 4 -d /)
+for back in $php_fpm
+do
+    if [ -z "$php_fpm" ]; then
+        service $WEB_BACKEND restart >/dev/null 2>&1
+    else
+        service $back restart >/dev/null 2>&1
+    fi
+done
 
 if [ $? -ne 0 ]; then
     send_email_report

--- a/func/domain.sh
+++ b/func/domain.sh
@@ -84,7 +84,27 @@ is_web_alias_new() {
 
 # Prepare web backend
 prepare_web_backend() {
-    pool=$(find -L /etc/php* -type d \( -name "pool.d" -o -name "*fpm.d" \))
+    pool=$(find -L /etc/php/ -name "$domain.conf" -exec dirname {} \;)
+
+    #
+    # Check if multiple-PHP installed
+    #
+    regex="socket-(\d+)_(\d+)"
+    if [[ $template =~ ^socket-([0-9])\_([0-9])$ ]]
+    then
+        version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+        pool=$(find -L /etc/php/$version -type d \( -name "pool.d" -o -name "*fpm.d" \))
+    else
+        if [ "$pool" == "" ]
+        then
+            version=`echo "<?php echo (float)phpversion();" | php`
+            pool=$(find -L /etc/php/$version -type d \( -name "pool.d" -o -name "*fpm.d" \))
+        fi
+    fi
+    #
+    # /Check if multiple-PHP installed
+    #
+
     if [ ! -e "$pool" ]; then
         check_result $E_NOTEXIST "php-fpm pool doesn't exist"
     fi
@@ -100,6 +120,11 @@ prepare_web_backend() {
             backend_lsnr="unix:$backend_lsnr"
         fi
     fi
+}
+
+# Delete web backend
+delete_web_backend() {
+    find -L /etc/php/ -type f -name "$backend_type.conf" -exec rm -f {} \;
 }
 
 # Prepare web aliases


### PR DESCRIPTION
This PR allow to use multiple php-fpm directories (not only if you try to install multiple php, even if your system updates to a new php version).

function delete_web_backend is added on domain.sh for simplicity

function prepare_web_backend changed when try to detect pool directory, so detect right one. Plus, if you use socket_7_1, socket_5.3, etc files, it detect right pool