### PR TITLE
Setting lets encrypt hostname ssl auto-renewal during install

### DIFF
--- a/install/vst-install-amazon.sh
+++ b/install/vst-install-amazon.sh
@@ -54,6 +54,7 @@ help() {
   -l, --lang              Default language                default: en
   -y, --interactive       Interactive install   [yes|no]  default: yes
   -s, --hostname          Set hostname
+  -u, --ssl               Add LE SSL for hostname  [yes|no]  default: no
   -e, --email             Set admin email
   -p, --password          Set admin password
   -f, --force             Force installation
@@ -138,6 +139,7 @@ for arg; do
         --lang)                 args="${args}-l " ;;
         --interactive)          args="${args}-y " ;;
         --hostname)             args="${args}-s " ;;
+        --ssl)                  args="${args}-u " ;;
         --email)                args="${args}-e " ;;
         --password)             args="${args}-p " ;;
         --force)                args="${args}-f " ;;
@@ -172,6 +174,7 @@ while getopts "a:n:w:v:j:k:m:g:d:x:z:c:t:i:b:r:o:q:l:y:s:e:p:fh" Option; do
         l) lang=$OPTARG ;;              # Language
         y) interactive=$OPTARG ;;       # Interactive install
         s) servername=$OPTARG ;;        # Hostname
+        u) ssl=$OPTARG ;;               # Add Let's Encrypt SSL for hostname
         e) email=$OPTARG ;;             # Admin email
         p) vpass=$OPTARG ;;             # Admin password
         f) force='yes' ;;               # Force install
@@ -205,6 +208,7 @@ set_default_value 'remi' 'yes'
 set_default_value 'softaculous' 'yes'
 set_default_value 'quota' 'no'
 set_default_value 'interactive' 'yes'
+set_default_value 'ssl' 'no'
 set_default_lang 'en'
 
 # Checking software conflicts
@@ -1328,6 +1332,13 @@ $VESTA/upd/add_notifications.sh
 
 # Adding cronjob for autoupdates
 $VESTA/bin/v-add-cron-vesta-autoupdate
+
+# Add Let's Encrypt SSL for hostname and enable auto-renew
+if [ "$ssl" = 'yes' ]; then
+    $VESTA/bin/v-add-letsencrypt-domain 'admin' $(hostname) '' 'yes'
+    $VESTA/bin/v-update-host-certificate admin $(hostname)
+    echo "UPDATE_HOSTNAME_SSL='yes'" >> $VESTA/conf/vesta.conf
+fi
 
 
 #----------------------------------------------------------#

--- a/install/vst-install-amazon.sh
+++ b/install/vst-install-amazon.sh
@@ -1335,8 +1335,8 @@ $VESTA/bin/v-add-cron-vesta-autoupdate
 
 # Add Let's Encrypt SSL for hostname and enable auto-renew
 if [ "$ssl" = 'yes' ]; then
-    $VESTA/bin/v-add-letsencrypt-domain 'admin' $(hostname) '' 'yes'
-    $VESTA/bin/v-update-host-certificate admin $(hostname)
+    $VESTA/bin/v-add-letsencrypt-domain 'admin' $servername '' 'yes'
+    $VESTA/bin/v-update-host-certificate admin $servername
     echo "UPDATE_HOSTNAME_SSL='yes'" >> $VESTA/conf/vesta.conf
 fi
 

--- a/install/vst-install-amazon.sh
+++ b/install/vst-install-amazon.sh
@@ -33,26 +33,26 @@ software="nginx httpd mod_ssl mod_ruid2 mod_fcgid mod_extract_forwarded
 # Defining help function
 help() {
     echo "Usage: $0 [OPTIONS]
-  -a, --apache            Install Apache        [yes|no]  default: yes
-  -n, --nginx             Install Nginx         [yes|no]  default: yes
-  -w, --phpfpm            Install PHP-FPM       [yes|no]  default: no
-  -v, --vsftpd            Install Vsftpd        [yes|no]  default: yes
-  -j, --proftpd           Install ProFTPD       [yes|no]  default: no
-  -k, --named             Install Bind          [yes|no]  default: yes
-  -m, --mysql             Install MySQL         [yes|no]  default: yes
-  -g, --postgresql        Install PostgreSQL    [yes|no]  default: no
-  -d, --mongodb           Install MongoDB       [yes|no]  unsupported
-  -x, --exim              Install Exim          [yes|no]  default: yes
-  -z, --dovecot           Install Dovecot       [yes|no]  default: yes
-  -c, --clamav            Install ClamAV        [yes|no]  default: yes
-  -t, --spamassassin      Install SpamAssassin  [yes|no]  default: yes
-  -i, --iptables          Install Iptables      [yes|no]  default: yes
-  -b, --fail2ban          Install Fail2ban      [yes|no]  default: yes
-  -r, --remi              Install Remi repo     [yes|no]  default: yes
-  -o, --softaculous       Install Softaculous   [yes|no]  default: yes
-  -q, --quota             Filesystem Quota      [yes|no]  default: no
+  -a, --apache            Install Apache           [yes|no]  default: yes
+  -n, --nginx             Install Nginx            [yes|no]  default: yes
+  -w, --phpfpm            Install PHP-FPM          [yes|no]  default: no
+  -v, --vsftpd            Install Vsftpd           [yes|no]  default: yes
+  -j, --proftpd           Install ProFTPD          [yes|no]  default: no
+  -k, --named             Install Bind             [yes|no]  default: yes
+  -m, --mysql             Install MySQL            [yes|no]  default: yes
+  -g, --postgresql        Install PostgreSQL       [yes|no]  default: no
+  -d, --mongodb           Install MongoDB          [yes|no]  unsupported
+  -x, --exim              Install Exim             [yes|no]  default: yes
+  -z, --dovecot           Install Dovecot          [yes|no]  default: yes
+  -c, --clamav            Install ClamAV           [yes|no]  default: yes
+  -t, --spamassassin      Install SpamAssassin     [yes|no]  default: yes
+  -i, --iptables          Install Iptables         [yes|no]  default: yes
+  -b, --fail2ban          Install Fail2ban         [yes|no]  default: yes
+  -r, --remi              Install Remi repo        [yes|no]  default: yes
+  -o, --softaculous       Install Softaculous      [yes|no]  default: yes
+  -q, --quota             Filesystem Quota         [yes|no]  default: no
   -l, --lang              Default language                default: en
-  -y, --interactive       Interactive install   [yes|no]  default: yes
+  -y, --interactive       Interactive install      [yes|no]  default: yes
   -s, --hostname          Set hostname
   -u, --ssl               Add LE SSL for hostname  [yes|no]  default: no
   -e, --email             Set admin email
@@ -151,7 +151,7 @@ done
 eval set -- "$args"
 
 # Parsing arguments
-while getopts "a:n:w:v:j:k:m:g:d:x:z:c:t:i:b:r:o:q:l:y:s:e:p:fh" Option; do
+while getopts "a:n:w:v:j:k:m:g:d:x:z:c:t:i:b:r:o:q:l:y:s:u:e:p:fh" Option; do
     case $Option in
         a) apache=$OPTARG ;;            # Apache
         n) nginx=$OPTARG ;;             # Nginx

--- a/install/vst-install-debian.sh
+++ b/install/vst-install-debian.sh
@@ -61,25 +61,26 @@ fi
 # Defining help function
 help() {
     echo "Usage: $0 [OPTIONS]
-  -a, --apache            Install Apache        [yes|no]  default: yes
-  -n, --nginx             Install Nginx         [yes|no]  default: yes
-  -w, --phpfpm            Install PHP-FPM       [yes|no]  default: no
-  -v, --vsftpd            Install Vsftpd        [yes|no]  default: yes
-  -j, --proftpd           Install ProFTPD       [yes|no]  default: no
-  -k, --named             Install Bind          [yes|no]  default: yes
-  -m, --mysql             Install MySQL         [yes|no]  default: yes
-  -g, --postgresql        Install PostgreSQL    [yes|no]  default: no
-  -d, --mongodb           Install MongoDB       [yes|no]  unsupported
-  -x, --exim              Install Exim          [yes|no]  default: yes
-  -z, --dovecot           Install Dovecot       [yes|no]  default: yes
-  -c, --clamav            Install ClamAV        [yes|no]  default: yes
-  -t, --spamassassin      Install SpamAssassin  [yes|no]  default: yes
-  -i, --iptables          Install Iptables      [yes|no]  default: yes
-  -b, --fail2ban          Install Fail2ban      [yes|no]  default: yes
-  -o, --softaculous       Install Softaculous   [yes|no]  default: yes
-  -q, --quota             Filesystem Quota      [yes|no]  default: no
+  -a, --apache            Install Apache           [yes|no]  default: yes
+  -n, --nginx             Install Nginx            [yes|no]  default: yes
+  -w, --phpfpm            Install PHP-FPM          [yes|no]  default: no
+  -v, --vsftpd            Install Vsftpd           [yes|no]  default: yes
+  -j, --proftpd           Install ProFTPD          [yes|no]  default: no
+  -k, --named             Install Bind             [yes|no]  default: yes
+  -m, --mysql             Install MySQL            [yes|no]  default: yes
+  -g, --postgresql        Install PostgreSQL       [yes|no]  default: no
+  -d, --mongodb           Install MongoDB          [yes|no]  unsupported
+  -x, --exim              Install Exim             [yes|no]  default: yes
+  -z, --dovecot           Install Dovecot          [yes|no]  default: yes
+  -c, --clamav            Install ClamAV           [yes|no]  default: yes
+  -t, --spamassassin      Install SpamAssassin     [yes|no]  default: yes
+  -i, --iptables          Install Iptables         [yes|no]  default: yes
+  -b, --fail2ban          Install Fail2ban         [yes|no]  default: yes
+  -r, --remi              Install Remi repo        [yes|no]  default: yes
+  -o, --softaculous       Install Softaculous      [yes|no]  default: yes
+  -q, --quota             Filesystem Quota         [yes|no]  default: no
   -l, --lang              Default language                default: en
-  -y, --interactive       Interactive install   [yes|no]  default: yes
+  -y, --interactive       Interactive install      [yes|no]  default: yes
   -s, --hostname          Set hostname
   -u, --ssl               Add LE SSL for hostname  [yes|no]  default: no
   -e, --email             Set admin email
@@ -182,7 +183,7 @@ done
 eval set -- "$args"
 
 # Parsing arguments
-while getopts "a:n:w:v:j:k:m:g:d:x:z:c:t:i:b:r:o:q:l:y:s:e:p:fh" Option; do
+while getopts "a:n:w:v:j:k:m:g:d:x:z:c:t:i:b:r:o:q:l:y:s:u:e:p:fh" Option; do
     case $Option in
         a) apache=$OPTARG ;;            # Apache
         n) nginx=$OPTARG ;;             # Nginx

--- a/install/vst-install-debian.sh
+++ b/install/vst-install-debian.sh
@@ -81,6 +81,7 @@ help() {
   -l, --lang              Default language                default: en
   -y, --interactive       Interactive install   [yes|no]  default: yes
   -s, --hostname          Set hostname
+  -u, --ssl               Add LE SSL for hostname  [yes|no]  default: no
   -e, --email             Set admin email
   -p, --password          Set admin password
   -f, --force             Force installation
@@ -169,6 +170,7 @@ for arg; do
         --lang)                 args="${args}-l " ;;
         --interactive)          args="${args}-y " ;;
         --hostname)             args="${args}-s " ;;
+        --ssl)                  args="${args}-u " ;;
         --email)                args="${args}-e " ;;
         --password)             args="${args}-p " ;;
         --force)                args="${args}-f " ;;
@@ -203,6 +205,7 @@ while getopts "a:n:w:v:j:k:m:g:d:x:z:c:t:i:b:r:o:q:l:y:s:e:p:fh" Option; do
         l) lang=$OPTARG ;;              # Language
         y) interactive=$OPTARG ;;       # Interactive install
         s) servername=$OPTARG ;;        # Hostname
+        u) ssl=$OPTARG ;;               # Add Let's Encrypt SSL for hostname
         e) email=$OPTARG ;;             # Admin email
         p) vpass=$OPTARG ;;             # Admin password
         f) force='yes' ;;               # Force install
@@ -235,6 +238,7 @@ set_default_value 'fail2ban' 'yes'
 set_default_value 'softaculous' 'yes'
 set_default_value 'quota' 'no'
 set_default_value 'interactive' 'yes'
+set_default_value 'ssl' 'no'
 set_default_lang 'en'
 
 # Checking software conflicts
@@ -1351,6 +1355,13 @@ $VESTA/upd/add_notifications.sh
 
 # Adding cronjob for autoupdates
 $VESTA/bin/v-add-cron-vesta-autoupdate
+
+# Add Let's Encrypt SSL for hostname and enable auto-renew
+if [ "$ssl" = 'yes' ]; then
+    $VESTA/bin/v-add-letsencrypt-domain 'admin' $(hostname) '' 'yes'
+    $VESTA/bin/v-update-host-certificate admin $(hostname)
+    echo "UPDATE_HOSTNAME_SSL='yes'" >> $VESTA/conf/vesta.conf
+fi
 
 
 #----------------------------------------------------------#

--- a/install/vst-install-debian.sh
+++ b/install/vst-install-debian.sh
@@ -1359,8 +1359,8 @@ $VESTA/bin/v-add-cron-vesta-autoupdate
 
 # Add Let's Encrypt SSL for hostname and enable auto-renew
 if [ "$ssl" = 'yes' ]; then
-    $VESTA/bin/v-add-letsencrypt-domain 'admin' $(hostname) '' 'yes'
-    $VESTA/bin/v-update-host-certificate admin $(hostname)
+    $VESTA/bin/v-add-letsencrypt-domain 'admin' $servername '' 'yes'
+    $VESTA/bin/v-update-host-certificate admin $servername
     echo "UPDATE_HOSTNAME_SSL='yes'" >> $VESTA/conf/vesta.conf
 fi
 

--- a/install/vst-install-rhel.sh
+++ b/install/vst-install-rhel.sh
@@ -42,27 +42,28 @@ fi
 # Defining help function
 help() {
     echo "Usage: $0 [OPTIONS]
-  -a, --apache            Install Apache        [yes|no]  default: yes
-  -n, --nginx             Install Nginx         [yes|no]  default: yes
-  -w, --phpfpm            Install PHP-FPM       [yes|no]  default: no
-  -v, --vsftpd            Install Vsftpd        [yes|no]  default: yes
-  -j, --proftpd           Install ProFTPD       [yes|no]  default: no
-  -k, --named             Install Bind          [yes|no]  default: yes
-  -m, --mysql             Install MySQL         [yes|no]  default: yes
-  -g, --postgresql        Install PostgreSQL    [yes|no]  default: no
-  -d, --mongodb           Install MongoDB       [yes|no]  unsupported
-  -x, --exim              Install Exim          [yes|no]  default: yes
-  -z, --dovecot           Install Dovecot       [yes|no]  default: yes
-  -c, --clamav            Install ClamAV        [yes|no]  default: yes
-  -t, --spamassassin      Install SpamAssassin  [yes|no]  default: yes
-  -i, --iptables          Install Iptables      [yes|no]  default: yes
-  -b, --fail2ban          Install Fail2ban      [yes|no]  default: yes
-  -r, --remi              Install Remi repo     [yes|no]  default: yes
-  -o, --softaculous       Install Softaculous   [yes|no]  default: yes
-  -q, --quota             Filesystem Quota      [yes|no]  default: no
+  -a, --apache            Install Apache           [yes|no]  default: yes
+  -n, --nginx             Install Nginx            [yes|no]  default: yes
+  -w, --phpfpm            Install PHP-FPM          [yes|no]  default: no
+  -v, --vsftpd            Install Vsftpd           [yes|no]  default: yes
+  -j, --proftpd           Install ProFTPD          [yes|no]  default: no
+  -k, --named             Install Bind             [yes|no]  default: yes
+  -m, --mysql             Install MySQL            [yes|no]  default: yes
+  -g, --postgresql        Install PostgreSQL       [yes|no]  default: no
+  -d, --mongodb           Install MongoDB          [yes|no]  unsupported
+  -x, --exim              Install Exim             [yes|no]  default: yes
+  -z, --dovecot           Install Dovecot          [yes|no]  default: yes
+  -c, --clamav            Install ClamAV           [yes|no]  default: yes
+  -t, --spamassassin      Install SpamAssassin     [yes|no]  default: yes
+  -i, --iptables          Install Iptables         [yes|no]  default: yes
+  -b, --fail2ban          Install Fail2ban         [yes|no]  default: yes
+  -r, --remi              Install Remi repo        [yes|no]  default: yes
+  -o, --softaculous       Install Softaculous      [yes|no]  default: yes
+  -q, --quota             Filesystem Quota         [yes|no]  default: no
   -l, --lang              Default language                default: en
-  -y, --interactive       Interactive install   [yes|no]  default: yes
+  -y, --interactive       Interactive install      [yes|no]  default: yes
   -s, --hostname          Set hostname
+  -u, --ssl               Add LE SSL for hostname  [yes|no]  default: no
   -e, --email             Set admin email
   -p, --password          Set admin password
   -f, --force             Force installation
@@ -147,6 +148,7 @@ for arg; do
         --lang)                 args="${args}-l " ;;
         --interactive)          args="${args}-y " ;;
         --hostname)             args="${args}-s " ;;
+        --ssl)                  args="${args}-u " ;;
         --email)                args="${args}-e " ;;
         --password)             args="${args}-p " ;;
         --force)                args="${args}-f " ;;
@@ -158,7 +160,7 @@ done
 eval set -- "$args"
 
 # Parsing arguments
-while getopts "a:n:w:v:j:k:m:g:d:x:z:c:t:i:b:r:o:q:l:y:s:e:p:fh" Option; do
+while getopts "a:n:w:v:j:k:m:g:d:x:z:c:t:i:b:r:o:q:l:y:s:u:e:p:fh" Option; do
     case $Option in
         a) apache=$OPTARG ;;            # Apache
         n) nginx=$OPTARG ;;             # Nginx
@@ -181,6 +183,7 @@ while getopts "a:n:w:v:j:k:m:g:d:x:z:c:t:i:b:r:o:q:l:y:s:e:p:fh" Option; do
         l) lang=$OPTARG ;;              # Language
         y) interactive=$OPTARG ;;       # Interactive install
         s) servername=$OPTARG ;;        # Hostname
+        u) ssl=$OPTARG ;;               # Add Let's Encrypt SSL for hostname
         e) email=$OPTARG ;;             # Admin email
         p) vpass=$OPTARG ;;             # Admin password
         f) force='yes' ;;               # Force install
@@ -214,6 +217,7 @@ set_default_value 'remi' 'yes'
 set_default_value 'softaculous' 'yes'
 set_default_value 'quota' 'no'
 set_default_value 'interactive' 'yes'
+set_default_value 'ssl' 'no'
 set_default_lang 'en'
 
 # Checking software conflicts
@@ -860,7 +864,6 @@ chown root:mail $VESTA/ssl/*
 chmod 660 $VESTA/ssl/*
 rm /tmp/vst.pem
 
-
 #----------------------------------------------------------#
 #                     Configure Nginx                      #
 #----------------------------------------------------------#
@@ -1352,6 +1355,13 @@ $VESTA/upd/add_notifications.sh
 
 # Adding cronjob for autoupdates
 $VESTA/bin/v-add-cron-vesta-autoupdate
+
+# Add Let's Encrypt SSL for hostname and enable auto-renew
+if [ "$ssl" = 'yes' ]; then
+    $VESTA/bin/v-add-letsencrypt-domain 'admin' $(hostname) '' 'yes'
+    $VESTA/bin/v-update-host-certificate admin $(hostname)
+    echo "UPDATE_HOSTNAME_SSL='yes'" >> $VESTA/conf/vesta.conf
+fi
 
 
 #----------------------------------------------------------#

--- a/install/vst-install-rhel.sh
+++ b/install/vst-install-rhel.sh
@@ -1358,8 +1358,8 @@ $VESTA/bin/v-add-cron-vesta-autoupdate
 
 # Add Let's Encrypt SSL for hostname and enable auto-renew
 if [ "$ssl" = 'yes' ]; then
-    $VESTA/bin/v-add-letsencrypt-domain 'admin' $(hostname) '' 'yes'
-    $VESTA/bin/v-update-host-certificate admin $(hostname)
+    $VESTA/bin/v-add-letsencrypt-domain 'admin' $servername '' 'yes'
+    $VESTA/bin/v-update-host-certificate admin $servername
     echo "UPDATE_HOSTNAME_SSL='yes'" >> $VESTA/conf/vesta.conf
 fi
 

--- a/install/vst-install-ubuntu.sh
+++ b/install/vst-install-ubuntu.sh
@@ -1306,8 +1306,8 @@ $VESTA/bin/v-add-cron-vesta-autoupdate
 
 # Add Let's Encrypt SSL for hostname and enable auto-renew
 if [ "$ssl" = 'yes' ]; then
-    $VESTA/bin/v-add-letsencrypt-domain 'admin' $(hostname) '' 'yes'
-    $VESTA/bin/v-update-host-certificate admin $(hostname)
+    $VESTA/bin/v-add-letsencrypt-domain 'admin' $servername '' 'yes'
+    $VESTA/bin/v-update-host-certificate admin $servername
     echo "UPDATE_HOSTNAME_SSL='yes'" >> $VESTA/conf/vesta.conf
 fi
 

--- a/install/vst-install-ubuntu.sh
+++ b/install/vst-install-ubuntu.sh
@@ -41,25 +41,26 @@ fi
 # Defining help function
 help() {
     echo "Usage: $0 [OPTIONS]
-  -a, --apache            Install Apache        [yes|no]  default: yes
-  -n, --nginx             Install Nginx         [yes|no]  default: yes
-  -w, --phpfpm            Install PHP-FPM       [yes|no]  default: no
-  -v, --vsftpd            Install Vsftpd        [yes|no]  default: yes
-  -j, --proftpd           Install ProFTPD       [yes|no]  default: no
-  -k, --named             Install Bind          [yes|no]  default: yes
-  -m, --mysql             Install MySQL         [yes|no]  default: yes
-  -g, --postgresql        Install PostgreSQL    [yes|no]  default: no
-  -d, --mongodb           Install MongoDB       [yes|no]  unsupported
-  -x, --exim              Install Exim          [yes|no]  default: yes
-  -z, --dovecot           Install Dovecot       [yes|no]  default: yes
-  -c, --clamav            Install ClamAV        [yes|no]  default: yes
-  -t, --spamassassin      Install SpamAssassin  [yes|no]  default: yes
-  -i, --iptables          Install Iptables      [yes|no]  default: yes
-  -b, --fail2ban          Install Fail2ban      [yes|no]  default: yes
-  -o, --softaculous       Install Softaculous   [yes|no]  default: yes
-  -q, --quota             Filesystem Quota      [yes|no]  default: no
+  -a, --apache            Install Apache           [yes|no]  default: yes
+  -n, --nginx             Install Nginx            [yes|no]  default: yes
+  -w, --phpfpm            Install PHP-FPM          [yes|no]  default: no
+  -v, --vsftpd            Install Vsftpd           [yes|no]  default: yes
+  -j, --proftpd           Install ProFTPD          [yes|no]  default: no
+  -k, --named             Install Bind             [yes|no]  default: yes
+  -m, --mysql             Install MySQL            [yes|no]  default: yes
+  -g, --postgresql        Install PostgreSQL       [yes|no]  default: no
+  -d, --mongodb           Install MongoDB          [yes|no]  unsupported
+  -x, --exim              Install Exim             [yes|no]  default: yes
+  -z, --dovecot           Install Dovecot          [yes|no]  default: yes
+  -c, --clamav            Install ClamAV           [yes|no]  default: yes
+  -t, --spamassassin      Install SpamAssassin     [yes|no]  default: yes
+  -i, --iptables          Install Iptables         [yes|no]  default: yes
+  -b, --fail2ban          Install Fail2ban         [yes|no]  default: yes
+  -r, --remi              Install Remi repo        [yes|no]  default: yes
+  -o, --softaculous       Install Softaculous      [yes|no]  default: yes
+  -q, --quota             Filesystem Quota         [yes|no]  default: no
   -l, --lang              Default language                default: en
-  -y, --interactive       Interactive install   [yes|no]  default: yes
+  -y, --interactive       Interactive install      [yes|no]  default: yes
   -s, --hostname          Set hostname
   -u, --ssl               Add LE SSL for hostname  [yes|no]  default: no
   -e, --email             Set admin email
@@ -162,7 +163,7 @@ done
 eval set -- "$args"
 
 # Parsing arguments
-while getopts "a:n:w:v:j:k:m:g:d:x:z:c:t:i:b:r:o:q:l:y:s:e:p:fh" Option; do
+while getopts "a:n:w:v:j:k:m:g:d:x:z:c:t:i:b:r:o:q:l:y:s:u:e:p:fh" Option; do
     case $Option in
         a) apache=$OPTARG ;;            # Apache
         n) nginx=$OPTARG ;;             # Nginx

--- a/install/vst-install-ubuntu.sh
+++ b/install/vst-install-ubuntu.sh
@@ -61,6 +61,7 @@ help() {
   -l, --lang              Default language                default: en
   -y, --interactive       Interactive install   [yes|no]  default: yes
   -s, --hostname          Set hostname
+  -u, --ssl               Add LE SSL for hostname  [yes|no]  default: no
   -e, --email             Set admin email
   -p, --password          Set admin password
   -f, --force             Force installation
@@ -149,6 +150,7 @@ for arg; do
         --lang)                 args="${args}-l " ;;
         --interactive)          args="${args}-y " ;;
         --hostname)             args="${args}-s " ;;
+        --ssl)                  args="${args}-u " ;;
         --email)                args="${args}-e " ;;
         --password)             args="${args}-p " ;;
         --force)                args="${args}-f " ;;
@@ -183,6 +185,7 @@ while getopts "a:n:w:v:j:k:m:g:d:x:z:c:t:i:b:r:o:q:l:y:s:e:p:fh" Option; do
         l) lang=$OPTARG ;;              # Language
         y) interactive=$OPTARG ;;       # Interactive install
         s) servername=$OPTARG ;;        # Hostname
+        u) ssl=$OPTARG ;;               # Add Let's Encrypt SSL for hostname
         e) email=$OPTARG ;;             # Admin email
         p) vpass=$OPTARG ;;             # Admin password
         f) force='yes' ;;               # Force install
@@ -215,6 +218,7 @@ set_default_value 'fail2ban' 'yes'
 set_default_value 'softaculous' 'yes'
 set_default_value 'quota' 'no'
 set_default_value 'interactive' 'yes'
+set_default_value 'ssl' 'no'
 set_default_lang 'en'
 
 # Checking software conflicts
@@ -1298,6 +1302,13 @@ $VESTA/upd/add_notifications.sh
 
 # Adding cronjob for autoupdates
 $VESTA/bin/v-add-cron-vesta-autoupdate
+
+# Add Let's Encrypt SSL for hostname and enable auto-renew
+if [ "$ssl" = 'yes' ]; then
+    $VESTA/bin/v-add-letsencrypt-domain 'admin' $(hostname) '' 'yes'
+    $VESTA/bin/v-update-host-certificate admin $(hostname)
+    echo "UPDATE_HOSTNAME_SSL='yes'" >> $VESTA/conf/vesta.conf
+fi
 
 
 #----------------------------------------------------------#


### PR DESCRIPTION
I figured it might be useful to add an argument to the install scripts that takes advantage of the work @dpeca put into installing Let's Encrypt on the hostname and automating renewal.