### PR TITLE
Spamd install fix - Centos 7

### DIFF
--- a/install/vst-install-rhel.sh
+++ b/install/vst-install-rhel.sh
@@ -1177,8 +1177,8 @@ if [ "$spamd" = 'yes' ]; then
     service spamassassin start
     check_result $? "spamassassin start failed"
     if [ "$release" -ge '7' ]; then
-        useradd spamd -s /sbin/nologin -d /var/lib/spamassassin
-        mkdir /var/lib/spamassassin
+        useradd spamd -s /sbin/nologin -d /var/lib/spamassassin 2>/dev/null
+        mkdir -p /var/lib/spamassassin
         chown spamd:spamd /var/lib/spamassassin
     fi
 fi

--- a/install/vst-install-rhel.sh
+++ b/install/vst-install-rhel.sh
@@ -1177,9 +1177,7 @@ if [ "$spamd" = 'yes' ]; then
     service spamassassin start
     check_result $? "spamassassin start failed"
     if [ "$release" -ge '7' ]; then
-        groupadd -g 1001 spamd
-        useradd -u 1001 -g spamd -s /sbin/nologin -d \
-            /var/lib/spamassassin spamd
+        useradd spamd -s /sbin/nologin -d /var/lib/spamassassin
         mkdir /var/lib/spamassassin
         chown spamd:spamd /var/lib/spamassassin
     fi

--- a/upd/upgrade-centos-v16-to-v17.sh
+++ b/upd/upgrade-centos-v16-to-v17.sh
@@ -56,10 +56,8 @@ fi
 if [ -f "/etc/mail/spamassassin/local.cf" ] ; then
     if [ ! -d "/var/lib/spamassassin" ] ; then
         if [ "$release" -eq '7' ]; then
-            groupadd -g 1001 spamd
-            useradd -u 1001 -g spamd -s /sbin/nologin -d \
-                /var/lib/spamassassin spamd
-            mkdir /var/lib/spamassassin
+            useradd spamd -s /sbin/nologin -d /var/lib/spamassassin 2>/dev/null
+            mkdir -p /var/lib/spamassassin
             chown spamd:spamd /var/lib/spamassassin
         fi
     fi


### PR DESCRIPTION
This commit resolves some configuration errors for spamassassin that happen during installation on Centos 7.

The main install error is that the install script assumes that group id 1001 is available and tries to create group spamd. The fix is to forget about creating a group by id and instead create just the user.

I cleaned up some of the other code to be consistent with the rest of the script.