### PR TITLE
Proposed fix for the use of a deprecated directive in nginx

### DIFF
--- a/install/ubuntu/16.04/templates/web/nginx/caching.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/caching.stpl
@@ -1,7 +1,6 @@
 server {
-    listen      %ip%:%proxy_ssl_port%;
+    listen      %ip%:%proxy_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;

--- a/install/ubuntu/16.04/templates/web/nginx/default.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/default.stpl
@@ -1,7 +1,6 @@
 server {
-    listen      %ip%:%proxy_ssl_port%;
+    listen      %ip%:%proxy_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;

--- a/install/ubuntu/16.04/templates/web/nginx/hosting.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/hosting.stpl
@@ -1,7 +1,6 @@
 server {
-    listen      %ip%:%proxy_ssl_port%;
+    listen      %ip%:%proxy_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;

--- a/install/ubuntu/16.04/templates/web/nginx/http2.stpl
+++ b/install/ubuntu/16.04/templates/web/nginx/http2.stpl
@@ -1,7 +1,6 @@
 server {
-    listen      %ip%:%proxy_ssl_port% http2;
+    listen      %ip%:%proxy_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;


### PR DESCRIPTION
Tested on two live Ubuntu 16.04.5 LTS running nginx/1.15.8

Starting from a previous version of nginx, the use of  the directive `ssl on;` has been deprecated.
This Pull Request contains the proposed fixes of the nginx templates.

It's possible that this fix should be applied to Ubuntu 18.04 and others, but I have only tested that with nginx/1.15.8 on Ubuntu 16.04.5.