### PR TITLE
Fixing Typo error on Lets Encrypt validation

### DIFF
--- a/bin/v-add-letsencrypt-domain
+++ b/bin/v-add-letsencrypt-domain
@@ -190,7 +190,7 @@ for auth in $authz; do
         nonce=$(echo "$answer" |grep Nonce |cut -f2 -d \ |tr -d '\r\n')
         status=$(echo "$answer"|grep HTTP/1.1 |tail -n1 |cut -f 2 -d ' ')
         if [[ "$status" -ne 200 ]]; then
-            check_result $E_CONNECT "Let's Encrypt vvalidation status $status"
+            check_result $E_CONNECT "Let's Encrypt validation status $status"
         fi
 
         i=$((i + 1))


### PR DESCRIPTION
 #1812 
`check_result $E_CONNECT "Let's Encrypt vvalidation status $status"`  > `check_result $E_CONNECT "Let's Encrypt validation status $status"`