### PR TITLE
Update v-add-firewall-chain getting ssh port from ssh config file (not hardcoded)

### DIFF
--- a/bin/v-add-firewall-chain
+++ b/bin/v-add-firewall-chain
@@ -47,7 +47,13 @@ is_system_enabled "$FIREWALL_SYSTEM" 'FIREWALL_SYSTEM'
 
 # Checking known chains
 case $chain in
-    SSH)        port=22; protocol=TCP ;;
+    SSH)        # Get ssh port by reading ssh config file.
+                sshport=$(grep '^Port ' /etc/ssh/sshd_config | head -1 | cut -d ' ' -f 2)
+                if [ -z "$sshport" ]; then
+                    sshport=22
+                fi
+                port=$sshport; 
+                protocol=TCP ;;
     FTP)        port=21; protocol=TCP  ;;
     MAIL)       port='25,465,587,2525,110,995,143,993'; protocol=TCP  ;;
     DNS)        port=53; protocol=UDP  ;;


### PR DESCRIPTION
Obtains the SSH port from the service configuration file (originally it was hardcoded). This allows the correct creation of ssh chain when this service has a customized port.