### PR TITLE
add Vagrant support

### DIFF
--- a/func/ip.sh
+++ b/func/ip.sh
@@ -216,6 +216,7 @@ get_user_ip() {
     if [ ! -z "$nat" ]; then
         ip=$nat
     fi
+    grep -q "^vagrant" /etc/passwd && [ `hostname -I | wc -w` -gt 1 ] && ip=`hostname -I | cut -f 2 -d " "`
 }
 
 # Validate ip address


### PR DESCRIPTION
The folder /home/admin/conf/web/ has empty files after install Vesta on pure Vagrant systems (cenos/7, debian/stretch64, ubuntu/bionic64) if it is used option config.vm.network "private_network" or config.vm.network "public_network" in the Vagrantfile. This patch fix it.
My initial test on Ubuntu host and Centos host:
[Install VirtualBox](https://www.virtualbox.org/wiki/Downloads)
[Install last Vagrant](https://www.vagrantup.com/intro/getting-started/install.html)

```
cd
mkdir vesta
cd vesta
vagrant init centos/7
#uncomment config.vm.network "private_network" or config.vm.network "public_network" option in Vagrantfile
vagrant up
vagrant ssh
curl -O http://vestacp.com/pub/vst-install.sh
sudo bash vst-install.sh
hostname -I # to see right ip address
```
For exit:
```
exit
vagrant halt
vagrant destroy # only if need delete virtual machine
```