### PR TITLE
Fixing set dovecot user as owner of files when dovecot is not installed

### DIFF
--- a/bin/v-add-mail-domain
+++ b/bin/v-add-mail-domain
@@ -109,7 +109,7 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
 
     # Set ownership
     chown -R $MAIL_USER:mail $HOMEDIR/$user/conf/mail/$domain
-    # Checking if user dovecot exists. If it doesn't exist, owner is exim user.
+    # Checking if user dovecot exists. If dovecor user doesn't exist (dovecot is not installed), owner is exim user.
     if id "dovecot" >/dev/null 2>&1; then
         chown -R dovecot:mail $HOMEDIR/$user/conf/mail/$domain/passwd
     else

--- a/bin/v-add-mail-domain
+++ b/bin/v-add-mail-domain
@@ -109,7 +109,12 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
 
     # Set ownership
     chown -R $MAIL_USER:mail $HOMEDIR/$user/conf/mail/$domain
-    chown -R dovecot:mail $HOMEDIR/$user/conf/mail/$domain/passwd
+    # Checking if user dovecot exists. If it doesn't exist, owner is exim user.
+    if id "dovecot" >/dev/null 2>&1; then
+        chown -R dovecot:mail $HOMEDIR/$user/conf/mail/$domain/passwd
+    else
+        chown -R $MAIL_USER:mail $HOMEDIR/$user/conf/mail/$domain/passwd
+    fi
     chown $user:mail $HOMEDIR/$user/mail/$domain_idn
 fi
 

--- a/bin/v-update-firewall
+++ b/bin/v-update-firewall
@@ -51,6 +51,12 @@ if [ $? -ne 0 ]; then
     conntrack_ftp='no'
 fi
 
+# Checking custom OpenSSH  port
+sshport=$(grep '^Port ' /etc/ssh/sshd_config | head -1 | cut -d ' ' -f 2)
+if [[ "$sshport" =~ ^[0-9]+$ ]] && [ "$sshport" -ne "22"  ]; then
+    sed -i "s/PORT='22'/PORT=\'$sshport\'/" $rules
+fi
+
 # Creating temporary file
 tmp=$(mktemp)
 

--- a/bin/v-update-firewall
+++ b/bin/v-update-firewall
@@ -51,12 +51,6 @@ if [ $? -ne 0 ]; then
     conntrack_ftp='no'
 fi
 
-# Checking custom OpenSSH  port
-sshport=$(grep '^Port ' /etc/ssh/sshd_config | head -1 | cut -d ' ' -f 2)
-if [[ "$sshport" =~ ^[0-9]+$ ]] && [ "$sshport" -ne "22"  ]; then
-    sed -i "s/PORT='22'/PORT=\'$sshport\'/" $rules
-fi
-
 # Creating temporary file
 tmp=$(mktemp)
 

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -524,8 +524,14 @@ rebuild_mail_domain_conf() {
         chmod 660 $HOMEDIR/$user/conf/mail/$domain/*
         chmod 771 /etc/$MAIL_SYSTEM/domains/$domain_idn
         chmod 770 $HOMEDIR/$user/mail/$domain_idn
+        
+        # Checking if user dovecot exists. If dovecor user doesn't exist (dovecot is not installed), owner is exim user.
         chown -R $MAIL_USER:mail $HOMEDIR/$user/conf/mail/$domain
-        chown -R dovecot:mail $HOMEDIR/$user/conf/mail/$domain/passwd
+        if id "dovecot" >/dev/null 2>&1; then
+            chown -R dovecot:mail $HOMEDIR/$user/conf/mail/$domain/passwd
+        else
+            chown -R $MAIL_USER:mail $HOMEDIR/$user/conf/mail/$domain/passwd
+        fi
         chown $user:mail $HOMEDIR/$user/mail/$domain_idn
     fi
 

--- a/upd/fix_exim_permissions.sh
+++ b/upd/fix_exim_permissions.sh
@@ -1,11 +1,24 @@
 #!/bin/bash
 
+# Define mail user
+if [ "$MAIL_SYSTEM" = 'exim4' ]; then
+    MAIL_USER=Debian-exim
+else
+    MAIL_USER=exim
+fi
+
 if [ -e "/etc/exim4/domains/" ]; then
     for domain in $(ls /etc/exim4/domains/); do
         domain_link=$(readlink /etc/exim4/domains/$domain)
-        chown Debian-exim:mail $domain_link
-        chown Debian-exim:mail /etc/exim4/domains/$domain/*
-        chown dovecot:mail /etc/exim4/domains/$domain/passwd
+        chown $MAIL_USER:mail $domain_link
+        chown $MAIL_USER:mail /etc/exim4/domains/$domain/*
+    
+        # Checking if user dovecot exists. If dovecor user doesn't exist (dovecot is not installed), owner is exim user.
+        if id "dovecot" >/dev/null 2>&1; then
+            chown -R dovecot:mail /etc/exim4/domains/$domain/passwd
+        else
+            chown -R $MAIL_USER:mail /etc/exim4/domains/$domain/passwd
+        fi
     done
 fi
 


### PR DESCRIPTION
Dovecot is set as owner of several user's files even when dovecot is not installed.

This pull checks if dovecot user exists before set dovecot as owner. If dovecot user doesn't exist (dovecot is not installed), owner is assign to Exim user
