### PR TITLE
 Update v-update-firewall

### DIFF
--- a/bin/v-update-firewall
+++ b/bin/v-update-firewall
@@ -51,11 +51,6 @@ if [ $? -ne 0 ]; then
     conntrack_ftp='no'
 fi
 
-# Checking custom OpenSSH  port
-sshport=$(grep '^Port ' /etc/ssh/sshd_config | head -1 | cut -d ' ' -f 2)
-if [[ "$sshport" =~ ^[0-9]+$ ]] && [ "$sshport" -ne "22"  ]; then
-    sed -i "s/PORT='22'/PORT=\'$sshport\'/" $rules
-fi
 
 # Creating temporary file
 tmp=$(mktemp)


### PR DESCRIPTION
Check sshcustom port  is not needed anymore, because after merging pull 1819, the rules file already contains the ssh port correctly (it's not hardcoded anymore)

Also, if these lines are not removed, we have change ssh port, and we try to add a new rule with port 22 (v-add-firewall-rule DROP 0.0.0.0/0 22 tcp ssh) , these lines will change port 22 to current ssh port on rules.conf file, and we will be blocked.