### PR TITLE
Fix setting dovecot user as owner when Dovecot is not installed

### DIFF
--- a/bin/v-add-mail-domain
+++ b/bin/v-add-mail-domain
@@ -109,7 +109,12 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
 
     # Set ownership
     chown -R $MAIL_USER:mail $HOMEDIR/$user/conf/mail/$domain
-    chown -R dovecot:mail $HOMEDIR/$user/conf/mail/$domain/passwd
+    # Checking if dovecot user exists before set dovecot as owner. If dovecot user doesn't exist (dovecot is not installed), owner is assign to Exim user
+    if id "dovecot" >/dev/null 2>&1; then
+        chown -R dovecot:mail $HOMEDIR/$user/conf/mail/$domain/passwd
+    else
+        chown -R $MAIL_USER:mail $HOMEDIR/$user/conf/mail/$domain/passwd
+    fi
     chown $user:mail $HOMEDIR/$user/mail/$domain_idn
 fi
 

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -525,7 +525,13 @@ rebuild_mail_domain_conf() {
         chmod 771 /etc/$MAIL_SYSTEM/domains/$domain_idn
         chmod 770 $HOMEDIR/$user/mail/$domain_idn
         chown -R $MAIL_USER:mail $HOMEDIR/$user/conf/mail/$domain
-        chown -R dovecot:mail $HOMEDIR/$user/conf/mail/$domain/passwd
+
+        # Checking if dovecot user exists before set dovecot as owner. If dovecot user doesn't exist (dovecot is not installed), owner is assign to Exim user
+        if id "dovecot" >/dev/null 2>&1; then
+            chown -R dovecot:mail $HOMEDIR/$user/conf/mail/$domain/passwd
+        else
+            chown -R $MAIL_USER:mail $HOMEDIR/$user/conf/mail/$domain/passwd
+        fi
         chown $user:mail $HOMEDIR/$user/mail/$domain_idn
     fi
 

--- a/upd/fix_exim_permissions.sh
+++ b/upd/fix_exim_permissions.sh
@@ -5,7 +5,13 @@ if [ -e "/etc/exim4/domains/" ]; then
         domain_link=$(readlink /etc/exim4/domains/$domain)
         chown Debian-exim:mail $domain_link
         chown Debian-exim:mail /etc/exim4/domains/$domain/*
-        chown dovecot:mail /etc/exim4/domains/$domain/passwd
+
+        # Checking if dovecot user exists before set dovecot as owner. If dovecot user doesn't exist (dovecot is not installed), owner is assign to Exim user
+        if id "dovecot" >/dev/null 2>&1; then
+            chown -R dovecot:mail /etc/exim4/domains/$domain/passwd
+        else
+            chown -R $MAIL_USER:mail /etc/exim4/domains/$domain/passwd
+        fi
     done
 fi
 


### PR DESCRIPTION
Dovecot is set as owner of several user's files even when dovecot is not installed.

This pull checks if dovecot user exists before set dovecot as owner. If dovecot user doesn't exist (dovecot is not installed), owner is assign to Exim user