### PR TITLE
 Fixing blowfish_secret length (too short) [phpMyAdmin]

### DIFF
--- a/install/vst-install-amazon.sh
+++ b/install/vst-install-amazon.sh
@@ -74,6 +74,9 @@ gen_pass() {
     echo "$PASS"
 }
 
+# Defining 32 char blowfish_secret
+blowfish_secret=`openssl rand -base64 32`;
+
 # Defining return code check function
 check_result() {
     if [ $1 -ne 0 ]; then
@@ -1023,7 +1026,7 @@ if [ "$mysql" = 'yes' ]; then
         cp -f $vestacp/pma/phpMyAdmin.conf /etc/httpd/conf.d/
     fi
     cp -f $vestacp/pma/config.inc.conf /etc/phpMyAdmin/config.inc.php
-    sed -i "s/%blowfish_secret%/$(gen_pass)/g" /etc/phpMyAdmin/config.inc.php
+    sed -i "s/%blowfish_secret%/$blowfish_secret/g" /etc/phpMyAdmin/config.inc.php
 fi
 
 

--- a/install/vst-install-amazon.sh
+++ b/install/vst-install-amazon.sh
@@ -1026,7 +1026,7 @@ if [ "$mysql" = 'yes' ]; then
         cp -f $vestacp/pma/phpMyAdmin.conf /etc/httpd/conf.d/
     fi
     cp -f $vestacp/pma/config.inc.conf /etc/phpMyAdmin/config.inc.php
-    sed -i "s/%blowfish_secret%/$blowfish_secret/g" /etc/phpMyAdmin/config.inc.php
+    sed -i "s#%blowfish_secret#$blowfish_secret#g" /etc/phpMyAdmin/config.inc.php
 fi
 
 

--- a/install/vst-install-rhel.sh
+++ b/install/vst-install-rhel.sh
@@ -83,6 +83,9 @@ gen_pass() {
     echo "$PASS"
 }
 
+# Defining 32 char blowfish_secret
+blowfish_secret=`openssl rand -base64 32`;
+
 # Defining return code check function
 check_result() {
     if [ $1 -ne 0 ]; then
@@ -1043,7 +1046,7 @@ if [ "$mysql" = 'yes' ]; then
         cp -f $vestacp/pma/phpMyAdmin.conf /etc/httpd/conf.d/
     fi
     cp -f $vestacp/pma/config.inc.conf /etc/phpMyAdmin/config.inc.php
-    sed -i "s/%blowfish_secret%/$(gen_pass)/g" /etc/phpMyAdmin/config.inc.php
+    sed -i "s/%blowfish_secret%/$blowfish_secret/g" /etc/phpMyAdmin/config.inc.php
 fi
 
 

--- a/install/vst-install-rhel.sh
+++ b/install/vst-install-rhel.sh
@@ -1046,7 +1046,7 @@ if [ "$mysql" = 'yes' ]; then
         cp -f $vestacp/pma/phpMyAdmin.conf /etc/httpd/conf.d/
     fi
     cp -f $vestacp/pma/config.inc.conf /etc/phpMyAdmin/config.inc.php
-    sed -i "s/%blowfish_secret%/$blowfish_secret/g" /etc/phpMyAdmin/config.inc.php
+    sed -i "s#%blowfish_secret#$blowfish_secret#g" /etc/phpMyAdmin/config.inc.php
 fi
 
 


### PR DESCRIPTION
Fixing blowfish_secret length (too short) if not longer phpMyAdmin shows a warning:

>  The secret passphrase in configuration (blowfish_secret) is too short.
