### PR TITLE
[phpMyAdmin] - Fix warning and slow phpMyAdmin

### DIFF
--- a/install/debian/7/pma/config.inc.php
+++ b/install/debian/7/pma/config.inc.php
@@ -137,6 +137,13 @@ if (!empty($dbname)) {
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
 
+/*
+ * Temp dir for faster beahivour
+ *
+ */
+$cfg['TempDir']  = '/tmp';
+
+
 /* Support additional configurations */
 foreach (glob('/etc/phpmyadmin/conf.d/*.php') as $filename)
 {

--- a/install/debian/8/pma/config.inc.php
+++ b/install/debian/8/pma/config.inc.php
@@ -137,6 +137,13 @@ if (!empty($dbname)) {
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
 
+/*
+ * Temp dir for faster beahivour
+ *
+ */
+$cfg['TempDir']  = '/tmp';
+
+
 /* Support additional configurations */
 foreach (glob('/etc/phpmyadmin/conf.d/*.php') as $filename)
 {

--- a/install/debian/9/pma/config.inc.php
+++ b/install/debian/9/pma/config.inc.php
@@ -137,6 +137,13 @@ if (!empty($dbname)) {
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
 
+/*
+ * Temp dir for faster beahivour
+ *
+ */
+$cfg['TempDir']  = '/tmp';
+
+
 /* Support additional configurations */
 foreach (glob('/etc/phpmyadmin/conf.d/*.php') as $filename)
 {

--- a/install/rhel/5/pma/config.inc.conf
+++ b/install/rhel/5/pma/config.inc.conf
@@ -17,6 +17,12 @@
 $cfg['blowfish_secret'] = '%blowfish_secret%'; /* YOU MUST FILL IN THIS FOR COOKIE AUTH! */
 
 /*
+ * Temp dir for faster beahivour
+ *
+ */
+$cfg['TempDir']  = '/tmp';
+
+/*
  * Servers configuration
  */
 $i = 0;

--- a/install/rhel/6/pma/config.inc.conf
+++ b/install/rhel/6/pma/config.inc.conf
@@ -19,7 +19,7 @@ $cfg['blowfish_secret'] = '%blowfish_secret%'; /* YOU MUST FILL IN THIS FOR COOK
 /*
  * Temp dir for faster beahivour
  *
-*/
+ */
 $cfg['TempDir']  = '/tmp';
 
 /*

--- a/install/rhel/6/pma/config.inc.conf
+++ b/install/rhel/6/pma/config.inc.conf
@@ -17,6 +17,12 @@
 $cfg['blowfish_secret'] = '%blowfish_secret%'; /* YOU MUST FILL IN THIS FOR COOKIE AUTH! */
 
 /*
+ * Temp dir for faster beahivour
+ *
+*/
+$cfg['TempDir']  = '/tmp';
+
+/*
  * Servers configuration
  */
 $i = 0;

--- a/install/rhel/7/pma/config.inc.conf
+++ b/install/rhel/7/pma/config.inc.conf
@@ -19,7 +19,7 @@ $cfg['blowfish_secret'] = '%blowfish_secret%'; /* YOU MUST FILL IN THIS FOR COOK
 /*
  * Temp dir for faster beahivour
  *
-*/
+ */
 $cfg['TempDir']  = '/tmp';
 
 /*

--- a/install/rhel/7/pma/config.inc.conf
+++ b/install/rhel/7/pma/config.inc.conf
@@ -17,6 +17,12 @@
 $cfg['blowfish_secret'] = '%blowfish_secret%'; /* YOU MUST FILL IN THIS FOR COOKIE AUTH! */
 
 /*
+ * Temp dir for faster beahivour
+ *
+*/
+$cfg['TempDir']  = '/tmp';
+
+/*
  * Servers configuration
  */
 $i = 0;

--- a/install/ubuntu/12.04/pma/config.inc.php
+++ b/install/ubuntu/12.04/pma/config.inc.php
@@ -137,6 +137,12 @@ if (!empty($dbname)) {
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
 
+/*
+ * Temp dir for faster beahivour
+ *
+ */
+$cfg['TempDir']  = '/tmp';
+
 /* Support additional configurations */
 foreach (glob('/etc/phpmyadmin/conf.d/*.php') as $filename)
 {

--- a/install/ubuntu/12.10/pma/config.inc.php
+++ b/install/ubuntu/12.10/pma/config.inc.php
@@ -137,6 +137,12 @@ if (!empty($dbname)) {
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
 
+/*
+ * Temp dir for faster beahivour
+ *
+ */
+$cfg['TempDir']  = '/tmp';
+
 /* Support additional configurations */
 foreach (glob('/etc/phpmyadmin/conf.d/*.php') as $filename)
 {

--- a/install/ubuntu/13.04/pma/config.inc.php
+++ b/install/ubuntu/13.04/pma/config.inc.php
@@ -137,6 +137,12 @@ if (!empty($dbname)) {
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
 
+/*
+ * Temp dir for faster beahivour
+ *
+ */
+$cfg['TempDir']  = '/tmp';
+
 /* Support additional configurations */
 foreach (glob('/etc/phpmyadmin/conf.d/*.php') as $filename)
 {

--- a/install/ubuntu/13.10/pma/config.inc.php
+++ b/install/ubuntu/13.10/pma/config.inc.php
@@ -137,6 +137,12 @@ if (!empty($dbname)) {
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
 
+/*
+ * Temp dir for faster beahivour
+ *
+ */
+$cfg['TempDir']  = '/tmp';
+
 /* Support additional configurations */
 foreach (glob('/etc/phpmyadmin/conf.d/*.php') as $filename)
 {

--- a/install/ubuntu/14.04/pma/config.inc.php
+++ b/install/ubuntu/14.04/pma/config.inc.php
@@ -137,6 +137,12 @@ if (!empty($dbname)) {
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
 
+/*
+ * Temp dir for faster beahivour
+ *
+ */
+$cfg['TempDir']  = '/tmp';
+
 /* Support additional configurations */
 foreach (glob('/etc/phpmyadmin/conf.d/*.php') as $filename)
 {

--- a/install/ubuntu/14.10/pma/config.inc.php
+++ b/install/ubuntu/14.10/pma/config.inc.php
@@ -137,6 +137,12 @@ if (!empty($dbname)) {
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
 
+/*
+ * Temp dir for faster beahivour
+ *
+ */
+$cfg['TempDir']  = '/tmp';
+
 /* Support additional configurations */
 foreach (glob('/etc/phpmyadmin/conf.d/*.php') as $filename)
 {

--- a/install/ubuntu/15.04/pma/config.inc.php
+++ b/install/ubuntu/15.04/pma/config.inc.php
@@ -137,6 +137,12 @@ if (!empty($dbname)) {
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
 
+/*
+ * Temp dir for faster beahivour
+ *
+ */
+$cfg['TempDir']  = '/tmp';
+
 /* Support additional configurations */
 foreach (glob('/etc/phpmyadmin/conf.d/*.php') as $filename)
 {

--- a/install/ubuntu/15.10/pma/config.inc.php
+++ b/install/ubuntu/15.10/pma/config.inc.php
@@ -137,6 +137,12 @@ if (!empty($dbname)) {
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
 
+/*
+ * Temp dir for faster beahivour
+ *
+ */
+$cfg['TempDir']  = '/tmp';
+
 /* Support additional configurations */
 foreach (glob('/etc/phpmyadmin/conf.d/*.php') as $filename)
 {

--- a/install/ubuntu/16.04/pma/config.inc.php
+++ b/install/ubuntu/16.04/pma/config.inc.php
@@ -139,6 +139,12 @@ if (!empty($dbname)) {
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
 
+/*
+ * Temp dir for faster beahivour
+ *
+ */
+$cfg['TempDir']  = '/tmp';
+
 /* Support additional configurations */
 foreach (glob('/etc/phpmyadmin/conf.d/*.php') as $filename)
 {

--- a/install/ubuntu/16.10/pma/config.inc.php
+++ b/install/ubuntu/16.10/pma/config.inc.php
@@ -137,6 +137,12 @@ if (!empty($dbname)) {
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
 
+/*
+ * Temp dir for faster beahivour
+ *
+ */
+$cfg['TempDir']  = '/tmp';
+
 /* Support additional configurations */
 foreach (glob('/etc/phpmyadmin/conf.d/*.php') as $filename)
 {

--- a/install/ubuntu/17.04/pma/config.inc.php
+++ b/install/ubuntu/17.04/pma/config.inc.php
@@ -137,6 +137,12 @@ if (!empty($dbname)) {
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
 
+/*
+ * Temp dir for faster beahivour
+ *
+ */
+$cfg['TempDir']  = '/tmp';
+
 /* Support additional configurations */
 foreach (glob('/etc/phpmyadmin/conf.d/*.php') as $filename)
 {

--- a/install/ubuntu/17.10/pma/config.inc.php
+++ b/install/ubuntu/17.10/pma/config.inc.php
@@ -137,6 +137,12 @@ if (!empty($dbname)) {
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
 
+/*
+ * Temp dir for faster beahivour
+ *
+ */
+$cfg['TempDir']  = '/tmp';
+
 /* Support additional configurations */
 foreach (glob('/etc/phpmyadmin/conf.d/*.php') as $filename)
 {

--- a/install/ubuntu/18.04/pma/config.inc.php
+++ b/install/ubuntu/18.04/pma/config.inc.php
@@ -137,6 +137,12 @@ if (!empty($dbname)) {
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
 
+/*
+ * Temp dir for faster beahivour
+ *
+ */
+$cfg['TempDir']  = '/tmp';
+
 /* Support additional configurations */
 foreach (glob('/etc/phpmyadmin/conf.d/*.php') as $filename)
 {


### PR DESCRIPTION
Currently, phpMyAdmin is unable to access` /var/lib/phpMyAdmin/temp/` directory.
Setting `$cfg['TempDir']` to `/tmp` fixes warning and performance issues.

Warning:
>  The $cfg['TempDir'] (/var/lib/phpMyAdmin/temp/) is not accessible. phpMyAdmin is not able to cache templates and will be slow because of this.