### PR TITLE
Remove \n from dkim txt output

### DIFF
--- a/bin/v-list-mail-domain-dkim-dns
+++ b/bin/v-list-mail-domain-dkim-dns
@@ -67,7 +67,7 @@ is_object_valid 'mail' 'DOMAIN' "$domain"
 
 # Parsing domain keys
 if [ -e "$USER_DATA/mail/$domain.pub" ]; then
-    pub=$(cat $USER_DATA/mail/$domain.pub |grep -v "KEY-----")
+    pub=$(cat $USER_DATA/mail/$domain.pub |grep -v "KEY-----" |tr -d "\n\r")
     pub=$(echo "$pub" |sed ':a;N;$!ba;s/\n/\\n/g')
 else
     pub="DKIM-SUPPORT-IS-NOT-ACTIVATED"


### PR DESCRIPTION
Some DNS providers (like cloudflare) do not allow in dkim txt record \n char. Fix is removing new line symbols (\n).