### PR TITLE
Added Backblaze B2 experimental backup support

### DIFF
--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -859,6 +859,45 @@ google_backup() {
     fi
 }
 
+# BackBlaze B2 backup function
+backblazeb2_backup() {
+    # Defining backblaze b2 settings
+    source $VESTA/conf/b2.backup.conf
+    b2util=$(which b2)
+    # Recreate backblaze auth file ~/.b2_account_info (for situation when key was changed in b2.backup.conf)
+    $b2util clear-account > /dev/null 2>&1
+    $b2util authorize-account $B2_KEYID $B2_KEY > /dev/null 2>&1
+
+    # Checking retention
+    backup_list=$(${b2util} ls --long $BUCKET $user | cut -f 1 -d ' ' 2>/dev/null)
+    backups_count=$(echo "$backup_list" |wc -l)
+    if [ "$backups_count" -ge "$BACKUPS" ]; then
+        backups_rm_number=$((backups_count - BACKUPS))
+        for backup in $(echo "$backup_list" |head -n $backups_rm_number); do 
+            backup_file_name=$($b2util get-file-info $backup | grep fileName | cut -f 4 -d '"' 2>/dev/null)
+            echo -e "$(date "+%F %T") Rotated b2 backup: $backup_file_name"
+            $b2util delete-file-version $backup > /dev/null 2>&1
+        done
+    fi
+
+    # Uploading backup archive
+    echo -e "$(date "+%F %T") Uploading $user/$user.$backup_new_date.tar ..."
+    if [ "$localbackup" = 'yes' ]; then
+        cd $BACKUP
+        ${b2util} upload-file $BUCKET $user.$backup_new_date.tar $user/$user.$backup_new_date.tar > /dev/null 2>&1
+    else
+        cd $tmpdir
+        tar -cf $BACKUP/$user.$backup_new_date.tar .
+        cd $BACKUP/
+        ${b2util} upload-file $BUCKET $user.$backup_new_date.tar $user/$user.$backup_new_date.tar > /dev/null 2>&1
+        rc=$?
+        rm -f $user.$backup_new_date.tar
+        if [ "$rc" -ne 0 ]; then
+            check_result "$E_CONNECT" "b2 failed to upload $user.$backup_new_date.tar"
+        fi
+    fi
+}
+
 
 echo -e "\n-- SUMMARY --" |tee -a $BACKUP/$user.log
 
@@ -869,6 +908,7 @@ for backup_type in $(echo -e "${BACKUP_SYSTEM//,/\\n}"); do
         ftp)   ftp_backup ;;
         sftp)  sftp_backup ;;
         google) google_backup ;;
+        b2) backblazeb2_backup ;;
     esac
 done
 

--- a/bin/v-delete-user-backup
+++ b/bin/v-delete-user-backup
@@ -17,6 +17,22 @@ backup=$(echo $2| cut -f 2 -d \.)
 source $VESTA/func/main.sh
 source $VESTA/conf/vesta.conf
 
+backblazeb2_delete() {
+    # Defining backblaze settings
+    source $VESTA/conf/b2.backup.conf
+    b2util=$(which b2)
+    # Recreate backblaze auth file ~/.b2_account_info (for situation when key was changed in b2.backup.conf)
+    $b2util clear-account > /dev/null 2>&1
+    $b2util authorize-account $B2_KEYID $B2_KEY > /dev/null 2>&1
+    
+    # Define file id in b2 by backup file name
+    backup_file_id=$(${b2util} ls --long $BUCKET $user | grep "$backup" | cut -f 1 -d ' ' 2>/dev/null)
+    # Deleting file in b2
+    ${b2util} delete-file-version $backup_file_id > /dev/null 2>&1
+    if [ "$?" -ne 0 ]; then
+        check_result "$E_CONNECT" "b2 failed to delete $1"
+    fi
+}
 
 #----------------------------------------------------------#
 #                    Verifications                         #
@@ -33,8 +49,16 @@ is_object_valid 'backup' 'BACKUP' "$2"
 #                       Action                             #
 #----------------------------------------------------------#
 
-# Deleting backup
-rm -f $BACKUP/$2
+# Delete local/remote backups
+if [ ! -e "$BACKUP/$backup" ]; then
+   if [[ "$BACKUP_SYSTEM" =~ "b2" ]]; then
+         backblazeb2_delete $2
+   fi
+   if [[ "$BACKUP_SYSTEM" =~ "local" ]]; then
+         rm -f $BACKUP/$2
+   fi
+fi
+
 sed -i "/BACKUP='$2' /d" $USER_DATA/backup.conf
 
 

--- a/bin/v-restore-user
+++ b/bin/v-restore-user
@@ -159,6 +159,20 @@ google_download() {
     fi
 }
 
+# BackBlaze B2 backup download function
+backblazeb2_download() {
+    # Define b2 settings
+    source $VESTA/conf/b2.backup.conf
+    b2util=$(which b2)
+    # Recreate backblaze auth file ~/.b2_account_info (for situation when key was changed in b2.backup.conf)
+    $b2util clear-account > /dev/null 2>&1
+    $b2util authorize-account $B2_KEYID $B2_KEY > /dev/null 2>&1
+    #Download backup file from b2
+    ${b2util} download-file-by-name --noProgress $BUCKET $user/$backup $BACKUP/$backup > /dev/null 2>&1
+    if [ "$?" -ne 0 ]; then
+        check_result "$E_CONNECT" "b2 failed to download $1"
+    fi
+}
 
 #----------------------------------------------------------#
 #                    Verifications                         #
@@ -178,6 +192,10 @@ is_backup_available "$user" "$backup"
 if [ ! -e "$BACKUP/$backup" ]; then
     if [[ "$BACKUP_SYSTEM" =~ "google" ]]; then
         google_download $backup
+        downloaded='yes'
+    fi
+    if [[ "$BACKUP_SYSTEM" =~ "b2" ]]; then
+        backblazeb2_download $backup
         downloaded='yes'
     fi
     if [[ "$BACKUP_SYSTEM" =~ "sftp" ]] && [ -z "$downloaded" ]; then


### PR DESCRIPTION
Hello, glad to offer Backblaze B2 backups support to review.
Backup function works good.
Restore function works good.
Delete function works good.

What to do in future:
1. Refactor v-add-backup-host to cloud backups support (now, this script offer only FTP parameters like HOST/USER/PASSWORD).

**Usage**
1. Install python module "b2" (pip install b2)
2. Create $VESTA/conf/b2.backup.conf contains 
`BUCKET=<bucket_name>
B2_KEYID=<Application_Key_ID>
B2_KEY=<key>`
3. Change BACKUP_SYSTEM in $VESTA/conf/vesta.conf to "local,b2" or "b2"
Enjoy.