### PR TITLE
 Prevent v-backup-user from excluding folders named logs further down the tree

### DIFF
--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -223,7 +223,7 @@ if [ ! -z "$WEB_SYSTEM" ] && [ "$WEB" != '*' ]; then
         exlusion=$(echo -e "$WEB" |tr ',' '\n' |grep "^$domain:")
         set -f
         fargs=()
-        fargs+=(--exclude='logs/*')
+        fargs+=(--exclude='./logs/*')
         if [ ! -z "$exlusion" ]; then
             xdirs="$(echo -e "$exlusion" |tr ':' '\n' |grep -v $domain)"
             for xpath in $xdirs; do


### PR DESCRIPTION
This change will fix issues with files like `public_html/wp-content/plugins/sitepress-multilingual-cms/classes/logs/interface-wpml-log.php` from being excluded, but still exclude the intended main logs directory. Fixes a semi-widespread issue with VestaCP and WPML.