### PR TITLE
Fix for nginx exclude

### DIFF
--- a/install/vst-install-ubuntu.sh
+++ b/install/vst-install-ubuntu.sh
@@ -19,12 +19,12 @@ codename="$(lsb_release -s -c)"
 vestacp="$VESTA/install/$VERSION/$release"
 
 # Defining software pack for all distros
-software="apache2 apache2.2-common apache2-suexec-custom apache2-utils
+software="nginx apache2 apache2.2-common apache2-suexec-custom apache2-utils
     apparmor-utils awstats bc bind9 bsdmainutils bsdutils clamav-daemon
     cron curl dnsutils dovecot-imapd dovecot-pop3d e2fslibs e2fsprogs exim4
     exim4-daemon-heavy expect fail2ban flex ftp git idn imagemagick
     libapache2-mod-fcgid libapache2-mod-php libapache2-mod-rpaf
-    libapache2-mod-ruid2 lsof mc mysql-client mysql-common mysql-server nginx
+    libapache2-mod-ruid2 lsof mc mysql-client mysql-common mysql-server
     ntpdate php-cgi php-common php-curl php-fpm phpmyadmin php-mysql
     phppgadmin php-pgsql postgresql postgresql-contrib proftpd-basic quota
     roundcube-core roundcube-mysql roundcube-plugins rrdtool rssh spamassassin


### PR DESCRIPTION
There are some ways to fix this

First put nginx at the beginig or modify this line

software=$(echo "$software" | sed -e "s/^nginx//")
Replacing it by this one:
software=$(echo "$software" | sed -e "s/nginx//")
Or by this:
software=$(echo "$software" | sed -e "s/ nginx//")