### PR TITLE
Fix update of SSL for LetsEncrypt certs

### DIFF
--- a/bin/v-update-letsencrypt-ssl
+++ b/bin/v-update-letsencrypt-ssl
@@ -41,7 +41,7 @@ for user in $($BIN/v-list-users plain |cut -f 1); do
             fi
             ((lecounter++))
             aliases=$(echo "$crt_data" |grep DNS:)
-            aliases=$(echo "$aliases" |sed -e "s/DNS://g" -e "s/,//")
+            aliases=$(echo "$aliases" |sed -e "s/DNS://g" -e "s/,//g")
             aliases=$(echo "$aliases" |tr ' ' '\n' |sed "/^$/d")
             aliases=$(echo "$aliases" |grep -v "^$domain$")
             aliases=$(echo "$aliases" |sed -e ':a;N;$!ba;s/\n/,/g')


### PR DESCRIPTION
Due to missing /g in sed for parsing aliases from certificate SAN field there was an issue with doubled alias which is also common name of issued certificate.

/cc @pcfreak30 @serghey-rodin 