### PR TITLE
v-backup-user: Properly fix userdata backup exclusions

### DIFF
--- a/bin/v-backup-user
+++ b/bin/v-backup-user
@@ -460,11 +460,15 @@ if [ "$USER" != '*' ]; then
     fi
     fargs=()
     for xpath in $(echo "$USER" |tr ',' '\n'); do
-        fargs+=(-not)
-        fargs+=(-path)
-        fargs+=("./$xpath*")
-        echo "$(date "+%F %T") excluding directory $xpath" |\
+        if [ -d "$xpath" ]; then
+            fargs+=(--exclude=$xpath/*)
+            echo "$(date "+%F %T") excluding directory $xpath" |\
             tee -a $BACKUP/$user.log
+        else
+            echo "$(date "+%F %T") excluding file $xpath" |\
+            tee -a $BACKUP/$user.log
+            fargs+=(--exclude=$xpath)
+        fi
     done
 
     IFS=$'\n'
@@ -479,7 +483,7 @@ if [ "$USER" != '*' ]; then
             echo -e "$(date "+%F %T") adding $udir" |tee -a $BACKUP/$user.log
 
             # Backup files and dirs
-            tar -cpf- $udir |gzip -$BACKUP_GZIP - > $tmpdir/user_dir/$udir.tar.gz
+            tar --anchored -cpf- ${fargs[@]} $udir |gzip -$BACKUP_GZIP - > $tmpdir/user_dir/$udir.tar.gz
         fi
     done
     set +f


### PR DESCRIPTION
So far, no exclusions have been accounted for as fargs has not been passed.
Rework the logic for fargs parsing based on domain exclusions and pass fargs to the tar command.

Also add --anchored based on 37c69b8f4cd087d8d406ab3de766ad11564b978b