### PR TITLE
Renewal of cert not removing domain from alias list

### DIFF
--- a/bin/v-update-letsencrypt-ssl
+++ b/bin/v-update-letsencrypt-ssl
@@ -43,7 +43,7 @@ for user in $($BIN/v-list-users plain |cut -f 1); do
             aliases=$(echo "$crt_data" |grep DNS:)
             aliases=$(echo "$aliases" |sed -e "s/DNS://g" -e "s/,//g")
             aliases=$(echo "$aliases" |tr ' ' '\n' |sed "/^$/d")
-            aliases=$(echo "$aliases" |grep -v "^$domain$")
+            aliases=$(echo "$aliases" |grep -v "^$domain,$")
             aliases=$(echo "$aliases" |sed -e ':a;N;$!ba;s/\n/,/g')
             msg=$($BIN/v-add-letsencrypt-domain $user $domain $aliases)
             if [ $? -ne 0 ]; then


### PR DESCRIPTION
The domain SSL fails because the alias contains the domain name. The grep -v command is supposed to filter out the domain names but the earlier sed command appends a ',' to the end of the line, so the domain will never be removed with a ^ and $ either side of the $domain variable.

Simply appending a ',' to the end of the regex before the end of line $ will match and remove it successfully. 