### PR TITLE
Switched to egrep to support optional comma in renewal

### DIFF
--- a/bin/v-update-letsencrypt-ssl
+++ b/bin/v-update-letsencrypt-ssl
@@ -43,7 +43,7 @@ for user in $($BIN/v-list-users plain |cut -f 1); do
             aliases=$(echo "$crt_data" |grep DNS:)
             aliases=$(echo "$aliases" |sed -e "s/DNS://g" -e "s/,//g")
             aliases=$(echo "$aliases" |tr ' ' '\n' |sed "/^$/d")
-            aliases=$(echo "$aliases" |grep -v "^$domain,$")
+            aliases=$(echo "$aliases" |egrep -v "^$domain,?$")
             aliases=$(echo "$aliases" |sed -e ':a;N;$!ba;s/\n/,/g')
             msg=$($BIN/v-add-letsencrypt-domain $user $domain $aliases)
             if [ $? -ne 0 ]; then


### PR DESCRIPTION
Turns out that when you don't have an alias on the domain, you need to make the comma in the renewal an optional element in the grep function. Switched it to use egrep and made the comma an optional element