### PR TITLE
Split long TXT Entries into 255 Chunks

### DIFF
--- a/func/domain.sh
+++ b/func/domain.sh
@@ -412,6 +412,10 @@ update_domain_zone() {
             VALUE=$(idn --quiet -a -t "$VALUE")
         fi
 
+        if [ "$TYPE" = 'TXT' ] && [[ ${VALUE:0:1} != '"' ]]; then
+            VALUE=$(echo $VALUE | fold -w 255 | xargs -I '$' echo -n '"$"')
+        fi
+
         if [ "$SUSPENDED" != 'yes' ]; then
             eval echo -e "\"$fields\""|sed "s/%quote%/'/g" >> $zn_conf
         fi


### PR DESCRIPTION
If a TXT entry is not surrounded by double quotes, split it into 255 Chunks.
This is needed especially for domain keys with long text.
So you are not needed to set up the quotes manually.
And you can not damage your zone with wrong set quotes