### PR TITLE
Improve error 400 details updating LE challenge

### DIFF
--- a/bin/v-add-letsencrypt-domain
+++ b/bin/v-add-letsencrypt-domain
@@ -200,8 +200,9 @@ for auth in $authz; do
         validation=$(echo "$answer"|grep -A1 $proto |tail -n1|cut -f4 -d \")
         nonce=$(echo "$answer" |grep Nonce |cut -f2 -d \ |tr -d '\r\n')
         status=$(echo "$answer"|grep HTTP/1.1 |tail -n1 |cut -f 2 -d ' ')
+        details=$(echo "$answer"| grep detail | cut -f 2 -d ',' | cut -f 2-4 -d ':')
         if [[ "$status" -ne 200 ]]; then
-            check_result $E_CONNECT "Let's Encrypt validation status $status"
+            check_result $E_CONNECT "Let's Encrypt validation status $status. Details: $details"
         fi
 
         i=$((i + 1))


### PR DESCRIPTION
In a string like: 

`{ "type": "urn:ietf:params:acme:error:malformed", "detail": "Unable to update challenge :: authorization must be pending", "status": 400 }`

It picks the value for "details". So the user will have more info about the let's encrypt error and not only a 400 blind error, for example:

Instead of only:
`Error: Let's Encrypt validation status 400`

Now is improved to:

`Error: Let's Encrypt validation status 400. Details: Unable to update challenge :: authorization must be pending`