### PR TITLE
Only exclude logs folder from root, not in public_html

### DIFF
--- a/bin/v-restore-user
+++ b/bin/v-restore-user
@@ -409,7 +409,7 @@ if [ "$web" != 'no' ] && [ ! -z "$WEB_SYSTEM" ]; then
         chown $user $tmpdir
         chmod u+w $HOMEDIR/$user/web/$domain
         sudo -u $user tar -xzpf $tmpdir/web/$domain/domain_data.tar.gz \
-            -C $HOMEDIR/$user/web/$domain/ --exclude=logs/* \
+            -C $HOMEDIR/$user/web/$domain/ --exclude=./logs/* \
             2> $HOMEDIR/$user/web/$domain/restore_errors.log
         if [ -e "$HOMEDIR/$user/web/$domain/restore_errors.log" ]; then
             chown $user:$user $HOMEDIR/$user/web/$domain/restore_errors.log


### PR DESCRIPTION
Restoring should not exclude logs in any folder down the tree. This causes errors when restoring wordpress with certain plugins that have folders named "logs". This change aligns the restore with the backup function https://github.com/serghey-rodin/vesta/blob/master/bin/v-backup-user#L226

You could also omit the exclusion entirely, as this folder you are excluding should never be in the backup.