### PR TITLE
Fix issue #1977 / Letsencrypt ssl certificate update fails

### DIFF
--- a/bin/v-delete-web-domain-ssl
+++ b/bin/v-delete-web-domain-ssl
@@ -57,7 +57,13 @@ fi
 
 # Deleting old certificate
 tmpdir=$(mktemp -p $HOMEDIR/$user/web/$domain/private -d)
-rm -f $HOMEDIR/$user/conf/web/ssl.$domain.*
+
+# remove certificate files - do not use wildcard, as this might remove other domains
+rm -f $HOMEDIR/$user/conf/web/ssl.$domain.ca
+rm -f $HOMEDIR/$user/conf/web/ssl.$domain.crt
+rm -f $HOMEDIR/$user/conf/web/ssl.$domain.key
+rm -f $HOMEDIR/$user/conf/web/ssl.$domain.pem
+
 mv $USER_DATA/ssl/$domain.* $tmpdir
 chown -R $user:$user $tmpdir
 


### PR DESCRIPTION
Letsencrypt ssl certificate update fails when you have domains like example.com and example.com.ua (beginning matches)

issue #1977 https://github.com/serghey-rodin/vesta/issues/1977