### PR TITLE
Fix reset password from CLI / roundcube

### DIFF
--- a/bin/v-change-mail-account-password
+++ b/bin/v-change-mail-account-password
@@ -52,8 +52,11 @@ salt=$(generate_password "$PW_MATRIX" "8")
 md5="{MD5}$($BIN/v-generate-password-hash md5 $salt <<<$password)"
 
 if [[ "$MAIL_SYSTEM" =~ exim ]]; then
+    quota=$(grep $account $VESTA/data/users/${user}/mail/${domain}.conf)
+    quota=$(echo $quota | awk '{ print $7 }' | sed -e "s/'//g" )
+    quota=$(echo $quota | cut -d "=" -f 2 | sed -e "s/unlimited/0/g")
     sed -i "/^$account:/d" $HOMEDIR/$user/conf/mail/$domain/passwd
-    str="$account:$md5:$user:mail::$HOMEDIR/$user:$quota"
+    str="$account:$md5:$user:mail::$HOMEDIR/$user:${quota}M"
     echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
 fi
 


### PR DESCRIPTION
This will fix bug when change password from cli

$quota is not defined
I not know if there is any function to get quota with a single comand, so I get alredy defined quota

With out this vesta will reset quota or not asign nothing in passwd file when quota password was reset