### PR TITLE
Update url grep to https:// to prevent matching on token

### DIFF
--- a/bin/v-add-letsencrypt-domain
+++ b/bin/v-add-letsencrypt-domain
@@ -137,7 +137,7 @@ fi
 for auth in $authz; do
     payload=''
     answer=$(query_le_v2 "$auth" "$payload" "$nonce")
-    url=$(echo "$answer" |grep -A3 $proto |grep url |cut -f 4 -d \")
+    url=$(echo "$answer" |grep -A3 $proto |grep "https://" |cut -f 4 -d \")
     token=$(echo "$answer" |grep -A3 $proto |grep token |cut -f 4 -d \")
     nonce=$(echo "$answer" |grep -i nonce |cut -f2 -d \ |tr -d '\r\n')
     status=$(echo "$answer"|grep HTTP/ |tail -n1 |cut -f 2 -d ' ')


### PR DESCRIPTION
I came across the issue where the token contains `url` in the string,
which leads to grep matching on both url and token causing the
`query_le_v2` to fail because the first parsed argument is the url
which is separated by a newline and the token. This eventually leads to
error 15 while requesting a certificate. After some debugging I found
what the issue was. Therefore I'm proposing to make the grep more strict
on `https://`.

```
cat /tmp/answer.tmp | grep -A3 http-01 |grep url | cut -f 4 -d \"
https://acme-v02.api.letsencrypt.org/acme/chall-v3/6485980305/wTviug
qGBQk2j13cYDYkaSZs8urlYsY-VYQCGjJexfU6Yx-cQ

```
after my fix:
```
cat /tmp/answer.tmp | grep -A3 http-01 |grep "https://" | cut -f 4 -d \"
https://acme-v02.api.letsencrypt.org/acme/chall-v3/6485980305/wTviug
```