### PR TITLE
Update v-update-sys-rrd-mem

### DIFF
--- a/bin/v-update-sys-rrd-mem
+++ b/bin/v-update-sys-rrd-mem
@@ -61,13 +61,13 @@ fi
 # Parsing data
 if [ "$period" = 'daily' ]; then
     mem=$(free -m)
-    used=$(echo "$mem" |grep Mem |awk '{print $3}')
+    used=$(echo "$mem" |awk '(NR == 2)' |awk '{print $3}')
     if [ -z "$(echo "$mem" | grep available)" ]; then
-        free=$(echo "$mem" |grep buffers/cache |awk '{print $4}')
+        free=$(echo "$mem" |grep buff/cache |awk '{print $4}')
     else
-        free=$(echo "$mem" |grep Mem |awk '{print $7}')
+        free=$(echo "$mem" |awk '(NR == 2)' |awk '{print $7}')
     fi
-    swap=$(echo "$mem" |grep Swap |awk '{print $3}')
+    swap=$(echo "$mem" |awk '(NR == 3)' |awk '{print $3}')
 
     # Updating rrd
     rrdtool update $RRD/mem/mem.rrd N:$used:$swap:$free


### PR DESCRIPTION
Заменил фильтрацию по словам с использованием grep на адресацию по номеру строки. 
Подробнее описал тут: https://github.com/serghey-rodin/vesta/pull/1546#issuecomment-738750426

В этом решении практически нет привязки к языку, установленному на сервере, т.к. вторая строка - всегда память, а третья - подкачка. 
Пока оставил `if [ -z "$(echo "$mem" | grep available)" ]`, но исправил в нем ошибку (слово buff вместо buffers).
Я бы его вообще удалил и оставил только else ветку, но это обсуждаемо. 