### PR TITLE
[Action May Be Required] Changes to Cloudflare Infrastructure IPs Lis…

### DIFF
--- a/install/rhel/7/nginx/nginx.conf
+++ b/install/rhel/7/nginx/nginx.conf
@@ -75,7 +75,9 @@ http {
     set_real_ip_from   103.21.244.0/22;
     set_real_ip_from   103.22.200.0/22;
     set_real_ip_from   103.31.4.0/22;
-    set_real_ip_from   104.16.0.0/12;
+    set_real_ip_from   104.16.0.0/13;
+    set_real_ip_from   104.24.0.0/14;
+    #set_real_ip_from   104.16.0.0/12;
     set_real_ip_from   108.162.192.0/18;
     set_real_ip_from   131.0.72.0/22;
     set_real_ip_from   141.101.64.0/18;


### PR DESCRIPTION
…ted on cloudflare.com/ips

If your security model relies on allowing a list of trusted Cloudflare IPs from cloudflare.com/ips (or via API) on your origin, please make the following changes to your allow list by May 7, 2021. This change is safe to make today.

Remove:
104.16.0.0/12

Add:
104.16.0.0/13
104.24.0.0/14