### PR TITLE
Fix if statement typo

### DIFF
--- a/bin/v-update-sys-vesta
+++ b/bin/v-update-sys-vesta
@@ -38,7 +38,7 @@ fi
 if [ "$package" = "vesta-php" ]; then
     valid=1
 fi
-fi [ "$package" = "vesta-ioncube" ]; then 
+if [ "$package" = "vesta-ioncube" ]; then 
     valid=1
 fi
 if [ "$package" = "vesta-softaculous" ]; then


### PR DESCRIPTION
Fixes following:
```
/usr/local/vesta/bin/v-update-sys-vesta: line 41: syntax error near unexpected token `fi'
/usr/local/vesta/bin/v-update-sys-vesta: line 41: `fi [ "$package" = "vesta-ioncube" ]; then '
/usr/local/vesta/bin/v-update-sys-vesta: line 41: syntax error near unexpected token `fi'
/usr/local/vesta/bin/v-update-sys-vesta: line 41: `fi [ "$package" = "vesta-ioncube" ]; then '
/usr/local/vesta/bin/v-update-sys-vesta: line 41: syntax error near unexpected token `fi'
/usr/local/vesta/bin/v-update-sys-vesta: line 41: `fi [ "$package" = "vesta-ioncube" ]; then '
/usr/local/vesta/bin/v-update-sys-vesta: line 41: syntax error near unexpected token `fi'
/usr/local/vesta/bin/v-update-sys-vesta: line 41: `fi [ "$package" = "vesta-ioncube" ]; then '
```