### PR TITLE
Write quota value without a size unit in mail passwd entry

### DIFF
--- a/bin/v-change-mail-account-password
+++ b/bin/v-change-mail-account-password
@@ -56,7 +56,7 @@ if [[ "$MAIL_SYSTEM" =~ exim ]]; then
     quota=$(echo $quota | awk '{ print $7 }' | sed -e "s/'//g" )
     quota=$(echo $quota | cut -d "=" -f 2 | sed -e "s/unlimited/0/g")
     sed -i "/^$account:/d" $HOMEDIR/$user/conf/mail/$domain/passwd
-    str="$account:$md5:$user:mail::$HOMEDIR/$user:${quota}M"
+    str="$account:$md5:$user:mail::$HOMEDIR/$user:${quota}"
     echo $str >> $HOMEDIR/$user/conf/mail/$domain/passwd
 fi
 


### PR DESCRIPTION
When `v-change-mail-account-password` is executed, it recreates a user's entry in `/etc/exim4/domains/<domain_name>/passwd` file with the 'M' symbol appended to the quota field, while other scripts that I looked into write only a number. In addition, the `quota` option in [`local_delivery`](https://github.com/serghey-rodin/vesta/blob/ddee8801a4bb608de51d34a10de188d3a0f82964/install/debian/9/exim/exim4.conf.template#L316) and [`local_spam_delivery`](https://github.com/serghey-rodin/vesta/blob/ddee8801a4bb608de51d34a10de188d3a0f82964/install/debian/9/exim/exim4.conf.template#L333) Exim4 transports also appends the 'M' symbol to the value read from the `passwd` file. This results in the following error when Exim4 tries to deliver a message to the user whose quota field contains the 'M' symbol:

```text
2021-11-01 10:54:17 1kuA5N-9281QA-3l == user@example.com R=localuser T=local_delivery defer (-1): Malformed value "0MM" (expansion of "${extract{6}{:}{${lookup{$local_part}lsearch{/etc/exim4/domains/$domain/passwd}}}}M") in local_delivery transport
```

I think it was meant to write entries in `passwd` file without the 'M' symbol, so I removed it from the script in my pull request.