### PR TITLE
Fix: profile-menu scss

### DIFF
--- a/src/react/src/components/MainNav/Panel/Panel.scss
+++ b/src/react/src/components/MainNav/Panel/Panel.scss
@@ -47,7 +47,7 @@ $textColor: #555;
       display: flex;
       justify-content: center;
       align-items: center;
-      
+
       a, button {
         display: flex;
         justify-content: center;
@@ -71,7 +71,7 @@ $textColor: #555;
 
     div.active {
       background: white;
-      
+
       a, button {
         color: $secondary;
         font-weight: bold;
@@ -144,7 +144,6 @@ $textColor: #555;
     width: auto;
 
     div {
-      width: 4rem;
       height: 100%;
     }
 
@@ -172,7 +171,7 @@ $textColor: #555;
     div + div a {
       color: #a4abad;
       font-weight: 700;
-    
+
       &:hover {
         color: $secondaryLight;
       }


### PR DESCRIPTION
Hello, With this update, I have confirmed that the line break of logout button happens to some of characters if you set it to a language other than English.
"width: 4rem;" Clearing this option worked just fine.

I wish it was corrected.

![1](https://user-images.githubusercontent.com/17105857/139926784-3d03ec53-eca8-4df3-a0be-c86b9e0cbe53.png)
![3](https://user-images.githubusercontent.com/17105857/139926813-e7ba46a2-8deb-478d-be8b-ced3c28d2298.png)

ps. This issue has been confirmed in the Windows OS Chrome browser.