### PR TITLE
Added sys_temp_dir to all apache/php-fpm configs

### DIFF
--- a/install/debian/7/pma/apache.conf
+++ b/install/debian/7/pma/apache.conf
@@ -15,6 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
+       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/debian/7/pma/apache.conf
+++ b/install/debian/7/pma/apache.conf
@@ -15,7 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
-       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
+		php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/debian/7/templates/web/apache2/basedir.stpl
+++ b/install/debian/7/templates/web/apache2/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/debian/7/templates/web/apache2/basedir.tpl
+++ b/install/debian/7/templates/web/apache2/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/debian/7/templates/web/apache2/default.stpl
+++ b/install/debian/7/templates/web/apache2/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/debian/7/templates/web/apache2/default.tpl
+++ b/install/debian/7/templates/web/apache2/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/debian/7/templates/web/apache2/hosting.stpl
+++ b/install/debian/7/templates/web/apache2/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/debian/7/templates/web/apache2/hosting.tpl
+++ b/install/debian/7/templates/web/apache2/hosting.tpl
@@ -14,7 +14,6 @@
     <Directory %docroot%>
         AllowOverride All
         Options +Includes -Indexes +ExecCGI
-        php_admin_value upload_tmp_dir %home%/%user%/tmp
         php_admin_value upload_max_filesize 10M
         php_admin_value max_execution_time 20
         php_admin_value post_max_size  8M
@@ -24,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/debian/7/templates/web/apache2/phpcgi.stpl
+++ b/install/debian/7/templates/web/apache2/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/debian/7/templates/web/apache2/phpcgi.tpl
+++ b/install/debian/7/templates/web/apache2/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/debian/7/templates/web/apache2/phpfcgid.stpl
+++ b/install/debian/7/templates/web/apache2/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/debian/7/templates/web/apache2/phpfcgid.tpl
+++ b/install/debian/7/templates/web/apache2/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/debian/7/templates/web/php5-fpm/default.tpl
+++ b/install/debian/7/templates/web/php5-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/debian/7/templates/web/php5-fpm/socket.tpl
+++ b/install/debian/7/templates/web/php5-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/debian/8/pma/apache.conf
+++ b/install/debian/8/pma/apache.conf
@@ -15,6 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
+       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/debian/8/pma/apache.conf
+++ b/install/debian/8/pma/apache.conf
@@ -15,7 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
-       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
+		php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/debian/8/templates/web/apache2/basedir.stpl
+++ b/install/debian/8/templates/web/apache2/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/debian/8/templates/web/apache2/basedir.tpl
+++ b/install/debian/8/templates/web/apache2/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/debian/8/templates/web/apache2/default.stpl
+++ b/install/debian/8/templates/web/apache2/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/debian/8/templates/web/apache2/default.tpl
+++ b/install/debian/8/templates/web/apache2/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/debian/8/templates/web/apache2/hosting.stpl
+++ b/install/debian/8/templates/web/apache2/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/debian/8/templates/web/apache2/hosting.tpl
+++ b/install/debian/8/templates/web/apache2/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/debian/8/templates/web/apache2/phpcgi.stpl
+++ b/install/debian/8/templates/web/apache2/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/debian/8/templates/web/apache2/phpcgi.tpl
+++ b/install/debian/8/templates/web/apache2/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/debian/8/templates/web/apache2/phpfcgid.stpl
+++ b/install/debian/8/templates/web/apache2/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/debian/8/templates/web/apache2/phpfcgid.tpl
+++ b/install/debian/8/templates/web/apache2/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/debian/8/templates/web/php5-fpm/default.tpl
+++ b/install/debian/8/templates/web/php5-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/debian/8/templates/web/php5-fpm/socket.tpl
+++ b/install/debian/8/templates/web/php5-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/debian/9/pma/apache.conf
+++ b/install/debian/9/pma/apache.conf
@@ -15,6 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
+       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/debian/9/pma/apache.conf
+++ b/install/debian/9/pma/apache.conf
@@ -15,7 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
-       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
+		php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/debian/9/templates/web/apache2/basedir.stpl
+++ b/install/debian/9/templates/web/apache2/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/debian/9/templates/web/apache2/basedir.tpl
+++ b/install/debian/9/templates/web/apache2/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/debian/9/templates/web/apache2/default.stpl
+++ b/install/debian/9/templates/web/apache2/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/debian/9/templates/web/apache2/default.tpl
+++ b/install/debian/9/templates/web/apache2/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/debian/9/templates/web/apache2/hosting.stpl
+++ b/install/debian/9/templates/web/apache2/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/debian/9/templates/web/apache2/hosting.tpl
+++ b/install/debian/9/templates/web/apache2/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/debian/9/templates/web/apache2/phpcgi.stpl
+++ b/install/debian/9/templates/web/apache2/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/debian/9/templates/web/apache2/phpcgi.tpl
+++ b/install/debian/9/templates/web/apache2/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/debian/9/templates/web/apache2/phpfcgid.stpl
+++ b/install/debian/9/templates/web/apache2/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/debian/9/templates/web/apache2/phpfcgid.tpl
+++ b/install/debian/9/templates/web/apache2/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/debian/9/templates/web/php-fpm/default.tpl
+++ b/install/debian/9/templates/web/php-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/debian/9/templates/web/php-fpm/socket.tpl
+++ b/install/debian/9/templates/web/php-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/rhel/5/templates/web/httpd/basedir.stpl
+++ b/install/rhel/5/templates/web/httpd/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/rhel/5/templates/web/httpd/basedir.tpl
+++ b/install/rhel/5/templates/web/httpd/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/rhel/5/templates/web/httpd/default.stpl
+++ b/install/rhel/5/templates/web/httpd/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/rhel/5/templates/web/httpd/default.tpl
+++ b/install/rhel/5/templates/web/httpd/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/rhel/5/templates/web/httpd/hosting.stpl
+++ b/install/rhel/5/templates/web/httpd/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/rhel/5/templates/web/httpd/hosting.tpl
+++ b/install/rhel/5/templates/web/httpd/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/rhel/5/templates/web/httpd/phpcgi.stpl
+++ b/install/rhel/5/templates/web/httpd/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/rhel/5/templates/web/httpd/phpcgi.tpl
+++ b/install/rhel/5/templates/web/httpd/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/rhel/5/templates/web/httpd/phpfcgid.stpl
+++ b/install/rhel/5/templates/web/httpd/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/rhel/5/templates/web/httpd/phpfcgid.tpl
+++ b/install/rhel/5/templates/web/httpd/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/rhel/5/templates/web/php-fpm/default.tpl
+++ b/install/rhel/5/templates/web/php-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/rhel/5/templates/web/php-fpm/socket.tpl
+++ b/install/rhel/5/templates/web/php-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/rhel/6/templates/web/httpd/basedir.stpl
+++ b/install/rhel/6/templates/web/httpd/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/rhel/6/templates/web/httpd/basedir.tpl
+++ b/install/rhel/6/templates/web/httpd/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/rhel/6/templates/web/httpd/default.stpl
+++ b/install/rhel/6/templates/web/httpd/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/rhel/6/templates/web/httpd/default.tpl
+++ b/install/rhel/6/templates/web/httpd/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/rhel/6/templates/web/httpd/hosting.stpl
+++ b/install/rhel/6/templates/web/httpd/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/rhel/6/templates/web/httpd/hosting.tpl
+++ b/install/rhel/6/templates/web/httpd/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/rhel/6/templates/web/httpd/phpcgi.stpl
+++ b/install/rhel/6/templates/web/httpd/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/rhel/6/templates/web/httpd/phpcgi.tpl
+++ b/install/rhel/6/templates/web/httpd/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/rhel/6/templates/web/httpd/phpfcgid.stpl
+++ b/install/rhel/6/templates/web/httpd/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/rhel/6/templates/web/httpd/phpfcgid.tpl
+++ b/install/rhel/6/templates/web/httpd/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/rhel/6/templates/web/php-fpm/default.tpl
+++ b/install/rhel/6/templates/web/php-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/rhel/6/templates/web/php-fpm/socket.tpl
+++ b/install/rhel/6/templates/web/php-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/rhel/7/templates/web/httpd/basedir.stpl
+++ b/install/rhel/7/templates/web/httpd/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/rhel/7/templates/web/httpd/basedir.tpl
+++ b/install/rhel/7/templates/web/httpd/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/rhel/7/templates/web/httpd/default.stpl
+++ b/install/rhel/7/templates/web/httpd/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/rhel/7/templates/web/httpd/default.tpl
+++ b/install/rhel/7/templates/web/httpd/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/rhel/7/templates/web/httpd/hosting.stpl
+++ b/install/rhel/7/templates/web/httpd/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/rhel/7/templates/web/httpd/hosting.tpl
+++ b/install/rhel/7/templates/web/httpd/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/rhel/7/templates/web/httpd/phpcgi.stpl
+++ b/install/rhel/7/templates/web/httpd/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/rhel/7/templates/web/httpd/phpcgi.tpl
+++ b/install/rhel/7/templates/web/httpd/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/rhel/7/templates/web/httpd/phpfcgid.stpl
+++ b/install/rhel/7/templates/web/httpd/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/rhel/7/templates/web/httpd/phpfcgid.tpl
+++ b/install/rhel/7/templates/web/httpd/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/rhel/7/templates/web/php-fpm/default.tpl
+++ b/install/rhel/7/templates/web/php-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/rhel/7/templates/web/php-fpm/socket.tpl
+++ b/install/rhel/7/templates/web/php-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/12.04/pma/apache.conf
+++ b/install/ubuntu/12.04/pma/apache.conf
@@ -15,6 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
+       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/ubuntu/12.04/pma/apache.conf
+++ b/install/ubuntu/12.04/pma/apache.conf
@@ -15,7 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
-       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
+		php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/ubuntu/12.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/12.04/templates/web/apache2/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/12.04/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/12.04/templates/web/apache2/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/12.04/templates/web/apache2/default.stpl
+++ b/install/ubuntu/12.04/templates/web/apache2/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/12.04/templates/web/apache2/default.tpl
+++ b/install/ubuntu/12.04/templates/web/apache2/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/12.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/12.04/templates/web/apache2/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/12.04/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/12.04/templates/web/apache2/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/12.04/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/12.04/templates/web/apache2/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/12.04/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/12.04/templates/web/apache2/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/12.04/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/12.04/templates/web/apache2/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/12.04/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/12.04/templates/web/apache2/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/12.04/templates/web/php-fpm/default.tpl
+++ b/install/ubuntu/12.04/templates/web/php-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/12.04/templates/web/php-fpm/socket.tpl
+++ b/install/ubuntu/12.04/templates/web/php-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/12.10/pma/apache.conf
+++ b/install/ubuntu/12.10/pma/apache.conf
@@ -15,6 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
+       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/ubuntu/12.10/pma/apache.conf
+++ b/install/ubuntu/12.10/pma/apache.conf
@@ -15,7 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
-       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
+		php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/ubuntu/12.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/12.10/templates/web/apache2/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/12.10/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/12.10/templates/web/apache2/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/12.10/templates/web/apache2/default.stpl
+++ b/install/ubuntu/12.10/templates/web/apache2/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/12.10/templates/web/apache2/default.tpl
+++ b/install/ubuntu/12.10/templates/web/apache2/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/12.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/12.10/templates/web/apache2/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/12.10/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/12.10/templates/web/apache2/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/12.10/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/12.10/templates/web/apache2/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/12.10/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/12.10/templates/web/apache2/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/12.10/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/12.10/templates/web/apache2/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/12.10/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/12.10/templates/web/apache2/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/12.10/templates/web/php-fpm/default.tpl
+++ b/install/ubuntu/12.10/templates/web/php-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/12.10/templates/web/php-fpm/socket.tpl
+++ b/install/ubuntu/12.10/templates/web/php-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/13.04/pma/apache.conf
+++ b/install/ubuntu/13.04/pma/apache.conf
@@ -15,6 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
+       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/ubuntu/13.04/pma/apache.conf
+++ b/install/ubuntu/13.04/pma/apache.conf
@@ -15,7 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
-       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
+		php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/ubuntu/13.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/13.04/templates/web/apache2/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/13.04/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/13.04/templates/web/apache2/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/13.04/templates/web/apache2/default.stpl
+++ b/install/ubuntu/13.04/templates/web/apache2/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/13.04/templates/web/apache2/default.tpl
+++ b/install/ubuntu/13.04/templates/web/apache2/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/13.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/13.04/templates/web/apache2/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/13.04/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/13.04/templates/web/apache2/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/13.04/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/13.04/templates/web/apache2/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/13.04/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/13.04/templates/web/apache2/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/13.04/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/13.04/templates/web/apache2/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/13.04/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/13.04/templates/web/apache2/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/13.04/templates/web/php-fpm/default.tpl
+++ b/install/ubuntu/13.04/templates/web/php-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/13.04/templates/web/php-fpm/socket.tpl
+++ b/install/ubuntu/13.04/templates/web/php-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/13.10/pma/apache.conf
+++ b/install/ubuntu/13.10/pma/apache.conf
@@ -15,6 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
+       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/ubuntu/13.10/pma/apache.conf
+++ b/install/ubuntu/13.10/pma/apache.conf
@@ -15,7 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
-       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
+		php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/ubuntu/13.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/13.10/templates/web/apache2/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/13.10/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/13.10/templates/web/apache2/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/13.10/templates/web/apache2/default.stpl
+++ b/install/ubuntu/13.10/templates/web/apache2/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/13.10/templates/web/apache2/default.tpl
+++ b/install/ubuntu/13.10/templates/web/apache2/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/13.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/13.10/templates/web/apache2/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/13.10/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/13.10/templates/web/apache2/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/13.10/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/13.10/templates/web/apache2/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/13.10/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/13.10/templates/web/apache2/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/13.10/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/13.10/templates/web/apache2/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/13.10/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/13.10/templates/web/apache2/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/13.10/templates/web/php-fpm/default.tpl
+++ b/install/ubuntu/13.10/templates/web/php-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/13.10/templates/web/php-fpm/socket.tpl
+++ b/install/ubuntu/13.10/templates/web/php-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/14.04/pma/apache.conf
+++ b/install/ubuntu/14.04/pma/apache.conf
@@ -15,6 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
+       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/ubuntu/14.04/pma/apache.conf
+++ b/install/ubuntu/14.04/pma/apache.conf
@@ -15,7 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
-       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
+		php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/ubuntu/14.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/14.04/templates/web/apache2/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/14.04/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/14.04/templates/web/apache2/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/14.04/templates/web/apache2/default.stpl
+++ b/install/ubuntu/14.04/templates/web/apache2/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/14.04/templates/web/apache2/default.tpl
+++ b/install/ubuntu/14.04/templates/web/apache2/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/14.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/14.04/templates/web/apache2/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/14.04/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/14.04/templates/web/apache2/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/14.04/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/14.04/templates/web/apache2/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/14.04/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/14.04/templates/web/apache2/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/14.04/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/14.04/templates/web/apache2/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/14.04/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/14.04/templates/web/apache2/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/14.04/templates/web/php-fpm/default.tpl
+++ b/install/ubuntu/14.04/templates/web/php-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/14.04/templates/web/php-fpm/socket.tpl
+++ b/install/ubuntu/14.04/templates/web/php-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/14.10/pma/apache.conf
+++ b/install/ubuntu/14.10/pma/apache.conf
@@ -15,6 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
+       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/ubuntu/14.10/pma/apache.conf
+++ b/install/ubuntu/14.10/pma/apache.conf
@@ -15,7 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
-       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
+		php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/ubuntu/14.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/14.10/templates/web/apache2/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/14.10/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/14.10/templates/web/apache2/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/14.10/templates/web/apache2/default.stpl
+++ b/install/ubuntu/14.10/templates/web/apache2/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/14.10/templates/web/apache2/default.tpl
+++ b/install/ubuntu/14.10/templates/web/apache2/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/14.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/14.10/templates/web/apache2/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/14.10/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/14.10/templates/web/apache2/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/14.10/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/14.10/templates/web/apache2/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/14.10/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/14.10/templates/web/apache2/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/14.10/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/14.10/templates/web/apache2/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/14.10/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/14.10/templates/web/apache2/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/14.10/templates/web/php-fpm/default.tpl
+++ b/install/ubuntu/14.10/templates/web/php-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/14.10/templates/web/php-fpm/socket.tpl
+++ b/install/ubuntu/14.10/templates/web/php-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/15.04/pma/apache.conf
+++ b/install/ubuntu/15.04/pma/apache.conf
@@ -15,6 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
+       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/ubuntu/15.04/pma/apache.conf
+++ b/install/ubuntu/15.04/pma/apache.conf
@@ -15,7 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
-       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
+		php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/ubuntu/15.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/15.04/templates/web/apache2/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/15.04/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/15.04/templates/web/apache2/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/15.04/templates/web/apache2/default.stpl
+++ b/install/ubuntu/15.04/templates/web/apache2/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/15.04/templates/web/apache2/default.tpl
+++ b/install/ubuntu/15.04/templates/web/apache2/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/15.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/15.04/templates/web/apache2/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/15.04/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/15.04/templates/web/apache2/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/15.04/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/15.04/templates/web/apache2/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/15.04/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/15.04/templates/web/apache2/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/15.04/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/15.04/templates/web/apache2/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/15.04/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/15.04/templates/web/apache2/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/15.04/templates/web/php-fpm/default.tpl
+++ b/install/ubuntu/15.04/templates/web/php-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/15.04/templates/web/php-fpm/socket.tpl
+++ b/install/ubuntu/15.04/templates/web/php-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/15.10/pma/apache.conf
+++ b/install/ubuntu/15.10/pma/apache.conf
@@ -15,6 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
+       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/ubuntu/15.10/pma/apache.conf
+++ b/install/ubuntu/15.10/pma/apache.conf
@@ -15,7 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
-       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
+		php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext
 	</IfModule>
 

--- a/install/ubuntu/15.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/15.10/templates/web/apache2/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/15.10/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/15.10/templates/web/apache2/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/15.10/templates/web/apache2/default.stpl
+++ b/install/ubuntu/15.10/templates/web/apache2/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/15.10/templates/web/apache2/default.tpl
+++ b/install/ubuntu/15.10/templates/web/apache2/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/15.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/15.10/templates/web/apache2/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/15.10/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/15.10/templates/web/apache2/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/15.10/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/15.10/templates/web/apache2/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/15.10/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/15.10/templates/web/apache2/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/15.10/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/15.10/templates/web/apache2/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/15.10/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/15.10/templates/web/apache2/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/15.10/templates/web/php-fpm/default.tpl
+++ b/install/ubuntu/15.10/templates/web/php-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/15.10/templates/web/php-fpm/socket.tpl
+++ b/install/ubuntu/15.10/templates/web/php-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/16.04/pma/apache.conf
+++ b/install/ubuntu/16.04/pma/apache.conf
@@ -15,7 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
-       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
+		php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext:/usr/share/javascript/
 	</IfModule>
 

--- a/install/ubuntu/16.04/pma/apache.conf
+++ b/install/ubuntu/16.04/pma/apache.conf
@@ -15,6 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
+       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext:/usr/share/javascript/
 	</IfModule>
 

--- a/install/ubuntu/16.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/16.04/templates/web/apache2/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/16.04/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/16.04/templates/web/apache2/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/16.04/templates/web/apache2/default.stpl
+++ b/install/ubuntu/16.04/templates/web/apache2/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/16.04/templates/web/apache2/default.tpl
+++ b/install/ubuntu/16.04/templates/web/apache2/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/16.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/16.04/templates/web/apache2/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/16.04/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/16.04/templates/web/apache2/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/16.04/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/16.04/templates/web/apache2/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/16.04/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/16.04/templates/web/apache2/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/16.04/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/16.04/templates/web/apache2/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/16.04/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/16.04/templates/web/apache2/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/16.04/templates/web/php-fpm/default.tpl
+++ b/install/ubuntu/16.04/templates/web/php-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/16.04/templates/web/php-fpm/socket.tpl
+++ b/install/ubuntu/16.04/templates/web/php-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/16.10/pma/apache.conf
+++ b/install/ubuntu/16.10/pma/apache.conf
@@ -15,7 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
-       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
+		php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext:/usr/share/javascript/
 	</IfModule>
 

--- a/install/ubuntu/16.10/pma/apache.conf
+++ b/install/ubuntu/16.10/pma/apache.conf
@@ -15,6 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
+       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext:/usr/share/javascript/
 	</IfModule>
 

--- a/install/ubuntu/16.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/16.10/templates/web/apache2/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/16.10/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/16.10/templates/web/apache2/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/16.10/templates/web/apache2/default.stpl
+++ b/install/ubuntu/16.10/templates/web/apache2/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/16.10/templates/web/apache2/default.tpl
+++ b/install/ubuntu/16.10/templates/web/apache2/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/16.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/16.10/templates/web/apache2/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/16.10/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/16.10/templates/web/apache2/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/16.10/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/16.10/templates/web/apache2/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/16.10/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/16.10/templates/web/apache2/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/16.10/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/16.10/templates/web/apache2/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/16.10/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/16.10/templates/web/apache2/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/16.10/templates/web/php-fpm/default.tpl
+++ b/install/ubuntu/16.10/templates/web/php-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/16.10/templates/web/php-fpm/socket.tpl
+++ b/install/ubuntu/16.10/templates/web/php-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/17.04/pma/apache.conf
+++ b/install/ubuntu/17.04/pma/apache.conf
@@ -15,7 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
-       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
+		php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext:/usr/share/javascript/
 	</IfModule>
 

--- a/install/ubuntu/17.04/pma/apache.conf
+++ b/install/ubuntu/17.04/pma/apache.conf
@@ -15,6 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
+       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext:/usr/share/javascript/
 	</IfModule>
 

--- a/install/ubuntu/17.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/17.04/templates/web/apache2/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/17.04/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/17.04/templates/web/apache2/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/17.04/templates/web/apache2/default.stpl
+++ b/install/ubuntu/17.04/templates/web/apache2/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/17.04/templates/web/apache2/default.tpl
+++ b/install/ubuntu/17.04/templates/web/apache2/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/17.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/17.04/templates/web/apache2/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/17.04/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/17.04/templates/web/apache2/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/17.04/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/17.04/templates/web/apache2/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/17.04/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/17.04/templates/web/apache2/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/17.04/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/17.04/templates/web/apache2/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/17.04/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/17.04/templates/web/apache2/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/17.04/templates/web/php-fpm/default.tpl
+++ b/install/ubuntu/17.04/templates/web/php-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/17.04/templates/web/php-fpm/socket.tpl
+++ b/install/ubuntu/17.04/templates/web/php-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/17.10/pma/apache.conf
+++ b/install/ubuntu/17.10/pma/apache.conf
@@ -15,7 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
-       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
+		php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext:/usr/share/javascript/
 	</IfModule>
 

--- a/install/ubuntu/17.10/pma/apache.conf
+++ b/install/ubuntu/17.10/pma/apache.conf
@@ -15,6 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
+       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext:/usr/share/javascript/
 	</IfModule>
 

--- a/install/ubuntu/17.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/17.10/templates/web/apache2/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/17.10/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/17.10/templates/web/apache2/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/17.10/templates/web/apache2/default.stpl
+++ b/install/ubuntu/17.10/templates/web/apache2/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/17.10/templates/web/apache2/default.tpl
+++ b/install/ubuntu/17.10/templates/web/apache2/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/17.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/17.10/templates/web/apache2/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/17.10/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/17.10/templates/web/apache2/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/17.10/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/17.10/templates/web/apache2/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/17.10/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/17.10/templates/web/apache2/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/17.10/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/17.10/templates/web/apache2/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/17.10/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/17.10/templates/web/apache2/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/17.10/templates/web/php-fpm/default.tpl
+++ b/install/ubuntu/17.10/templates/web/php-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/17.10/templates/web/php-fpm/socket.tpl
+++ b/install/ubuntu/17.10/templates/web/php-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/18.04/pma/apache.conf
+++ b/install/ubuntu/18.04/pma/apache.conf
@@ -15,7 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
-       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
+		php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext:/usr/share/javascript/
 	</IfModule>
 

--- a/install/ubuntu/18.04/pma/apache.conf
+++ b/install/ubuntu/18.04/pma/apache.conf
@@ -15,6 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
+       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext:/usr/share/javascript/
 	</IfModule>
 

--- a/install/ubuntu/18.04/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/18.04/templates/web/apache2/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/18.04/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/18.04/templates/web/apache2/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/18.04/templates/web/apache2/default.stpl
+++ b/install/ubuntu/18.04/templates/web/apache2/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/18.04/templates/web/apache2/default.tpl
+++ b/install/ubuntu/18.04/templates/web/apache2/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/18.04/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/18.04/templates/web/apache2/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/18.04/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/18.04/templates/web/apache2/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/18.04/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/18.04/templates/web/apache2/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/18.04/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/18.04/templates/web/apache2/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/18.04/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/18.04/templates/web/apache2/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/18.04/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/18.04/templates/web/apache2/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/18.04/templates/web/php-fpm/default.tpl
+++ b/install/ubuntu/18.04/templates/web/php-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/18.04/templates/web/php-fpm/socket.tpl
+++ b/install/ubuntu/18.04/templates/web/php-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/18.10/pma/apache.conf
+++ b/install/ubuntu/18.10/pma/apache.conf
@@ -15,7 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
-       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
+		php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext:/usr/share/javascript/
 	</IfModule>
 

--- a/install/ubuntu/18.10/pma/apache.conf
+++ b/install/ubuntu/18.10/pma/apache.conf
@@ -15,6 +15,7 @@ Alias /phpmyadmin /usr/share/phpmyadmin
 		php_admin_flag allow_url_fopen Off
 		php_value include_path .
 		php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
+       php_admin_value sys_temp_dir /var/lib/phpmyadmin/tmp
 		php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext:/usr/share/javascript/
 	</IfModule>
 

--- a/install/ubuntu/18.10/templates/web/apache2/basedir.stpl
+++ b/install/ubuntu/18.10/templates/web/apache2/basedir.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/18.10/templates/web/apache2/basedir.tpl
+++ b/install/ubuntu/18.10/templates/web/apache2/basedir.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
     </Directory>

--- a/install/ubuntu/18.10/templates/web/apache2/default.stpl
+++ b/install/ubuntu/18.10/templates/web/apache2/default.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %sdocroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/18.10/templates/web/apache2/default.tpl
+++ b/install/ubuntu/18.10/templates/web/apache2/default.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/18.10/templates/web/apache2/hosting.stpl
+++ b/install/ubuntu/18.10/templates/web/apache2/hosting.stpl
@@ -24,6 +24,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/18.10/templates/web/apache2/hosting.tpl
+++ b/install/ubuntu/18.10/templates/web/apache2/hosting.tpl
@@ -23,6 +23,7 @@
         php_admin_value sendmail_path "/usr/sbin/sendmail -t -i -f info@%domain_idn%"
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp:/bin:/usr/bin:/usr/local/bin:/var/www/html:/tmp:/usr/share:/etc/phpMyAdmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/etc/roundcubemail:/etc/roundcube:/var/lib/roundcube
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
     </Directory>
     <Directory %home%/%user%/web/%domain%/stats>

--- a/install/ubuntu/18.10/templates/web/apache2/phpcgi.stpl
+++ b/install/ubuntu/18.10/templates/web/apache2/phpcgi.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/18.10/templates/web/apache2/phpcgi.tpl
+++ b/install/ubuntu/18.10/templates/web/apache2/phpcgi.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         Action phpcgi-script /cgi-bin/php
         <Files *.php>

--- a/install/ubuntu/18.10/templates/web/apache2/phpfcgid.stpl
+++ b/install/ubuntu/18.10/templates/web/apache2/phpfcgid.stpl
@@ -17,6 +17,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/18.10/templates/web/apache2/phpfcgid.tpl
+++ b/install/ubuntu/18.10/templates/web/apache2/phpfcgid.tpl
@@ -16,6 +16,7 @@
         Options +Includes -Indexes +ExecCGI
         php_admin_value open_basedir %docroot%:%home%/%user%/tmp
         php_admin_value upload_tmp_dir %home%/%user%/tmp
+        php_admin_value sys_temp_dir %home%/%user%/tmp
         php_admin_value session.save_path %home%/%user%/tmp
         <Files *.php>
           SetHandler fcgid-script

--- a/install/ubuntu/18.10/templates/web/php-fpm/default.tpl
+++ b/install/ubuntu/18.10/templates/web/php-fpm/default.tpl
@@ -11,6 +11,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 

--- a/install/ubuntu/18.10/templates/web/php-fpm/socket.tpl
+++ b/install/ubuntu/18.10/templates/web/php-fpm/socket.tpl
@@ -14,6 +14,7 @@ pm.max_requests = 4000
 pm.process_idle_timeout = 10s
 pm.status_path = /status
 
+php_admin_value[sys_temp_dir] = /home/%user%/tmp
 php_admin_value[upload_tmp_dir] = /home/%user%/tmp
 php_admin_value[session.save_path] = /home/%user%/tmp
 


### PR DESCRIPTION
Some PHP applications use `sys_temp_dir` or `sys_get_temp_dir()` - this causes the error described in Issue #2234 .

This pull request adds the `sys_temp_dir` variable to all configs.
