### PR TITLE
Bugfix: remove fwd emails leaves fwd_only checkbox

### DIFF
--- a/web/api/v1/edit/mail/index.php
+++ b/web/api/v1/edit/mail/index.php
@@ -273,7 +273,7 @@ if ((!empty($_POST['save'])) && (!empty($_GET['domain'])) && (!empty($_GET['acco
     }
 
     // Delete FWD_ONLY flag
-    if (($v_fwd_only == 'yes') && (empty($_POST['v_fwd_only'])) && (empty($_SESSION['error_msg']))) {
+    if (($v_fwd_only == 'yes') && (empty($_POST['v_fwd_only']) or empty($forward)) && (empty($_SESSION['error_msg']))) {
         exec (VESTA_CMD."v-delete-mail-account-fwd-only ".$v_username." ".$v_domain." ".$v_account, $output, $return_var);
         check_return_code($return_var,$output);
         unset($output);


### PR DESCRIPTION
I managed to delete forwarding emails from an email account leaving the forward only checkbox checked, so the emails are not saved and also not forwarded.. I was also able to reproduce the error.
This will fix that: if no forwarding emails set, it will remove the checkbox of "Do not store forwarded mail".